### PR TITLE
Add portal search overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/xml+svg" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>iaie-students-knowledge-base</title>
   </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <mask id="p-cutout">
+    <rect width="128" height="128" fill="black"/>
+    <circle cx="64" cy="64" r="64" fill="white"/>
+    <rect x="52" y="30" width="22" height="74" rx="11" fill="black"/>
+    <path
+      d="M63 30H79C97 30 110 41 110 57C110 73 97 84 79 84H63V69H78C87 69 94 65 94 57C94 49 87 45 78 45H63Z"
+      fill="black"
+    />
+  </mask>
+
+  <rect width="128" height="128" fill="white" mask="url(#p-cutout)"/>
+</svg>

--- a/src/api/knowledgeBaseApi.ts
+++ b/src/api/knowledgeBaseApi.ts
@@ -15,5 +15,24 @@ export function searchKnowledgeBase(query: string, limit = 20): Promise<SearchRe
         limit: limit.toString()
     });
 
-    return getJson<SearchResponse>(`/api/search?${params.toString()}`);
+    return getJson<SearchResponse | {items?: SearchResponse["items"]} | {results?: SearchResponse["items"]} | SearchResponse["items"]>(`/api/search?${params.toString()}`)
+        .then((response) => {
+            if (Array.isArray(response)) {
+                return {items: response};
+            }
+
+            const queryValue = "query" in response && typeof response.query === "string" ? response.query : query;
+            const totalValue = "total" in response && typeof response.total === "number" ? response.total : undefined;
+            const itemsValue = "items" in response && Array.isArray(response.items)
+                ? response.items
+                : "results" in response && Array.isArray(response.results)
+                    ? response.results
+                    : [];
+
+            return {
+                query: queryValue,
+                total: totalValue,
+                items: itemsValue
+            };
+        });
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -24,15 +24,20 @@ export interface WorksByProjectTypeDto {
 
 export interface SearchResultItem {
     type: string
-    id?: number
+    id?: number | string
+    sourceId?: number
     authors?: string
     theme?: string
     published?: string
     link?: string
     title?: string
     hash?: string
+    groupTitle?: string | null
+    groupHash?: string | null
 }
 
 export interface SearchResponse {
-    results: SearchResultItem[]
+    query?: string
+    total?: number
+    items: SearchResultItem[]
 }

--- a/src/styles/common/Navbar.scss
+++ b/src/styles/common/Navbar.scss
@@ -1,13 +1,23 @@
 .site-header {
+  --site-header-top-height: 54px;
+  --site-header-main-height: 74px;
   position: sticky;
   top: 0;
-  z-index: 20;
+  z-index: 40;
+}
+
+.site-header-top,
+.site-header-main {
+  position: relative;
+  z-index: 3;
 }
 
 .site-header-top {
   display: flex;
   justify-content: flex-end;
+  min-height: var(--site-header-top-height);
   padding: 14px 40px;
+  box-sizing: border-box;
   background: #1f1f1f;
 }
 
@@ -38,8 +48,10 @@
 .site-header-main {
   display: flex;
   align-items: center;
+  min-height: var(--site-header-main-height);
   padding: 16px 40px;
-  background: rgba(255, 255, 255, 0.97);
+  box-sizing: border-box;
+  background: rgba(255, 255, 255, 0.98);
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
 }
 
@@ -122,6 +134,7 @@
 
 .site-navigation-menu-button {
   display: none;
+  align-items: center;
   gap: 8px;
   padding: 0 14px;
 }
@@ -177,8 +190,8 @@
 
 .site-navigation-dropdown-divider {
   height: 1px;
-  background: rgba(0, 0, 0, 0.08);
   margin: 4px 0;
+  background: rgba(0, 0, 0, 0.08);
 }
 
 .site-header-actions {
@@ -200,7 +213,16 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-height: 44px;
+  padding: 0 12px;
+  border-radius: 14px;
   font-size: 14px;
+  transition: background-color 160ms ease;
+}
+
+.site-search-button:hover,
+.site-search-button-active {
+  background: #f1f1f1 !important;
 }
 
 .site-search-button img {
@@ -220,6 +242,187 @@
   font-size: 14px;
 }
 
+.site-search-backdrop {
+  position: fixed;
+  inset: calc(var(--site-header-top-height) + var(--site-header-main-height)) 0 0;
+  z-index: 1;
+  border: 0;
+  background: rgba(20, 20, 20, 0.66);
+  backdrop-filter: blur(8px);
+}
+
+.site-search-panel {
+  position: fixed;
+  top: calc(var(--site-header-top-height) + var(--site-header-main-height));
+  left: 0;
+  right: 0;
+  z-index: 2;
+  padding: 18px 38px 26px;
+  background: rgba(255, 255, 255, 0.98);
+  border-bottom-left-radius: 28px;
+  border-bottom-right-radius: 28px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.18);
+}
+
+.site-search-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 16px;
+  align-items: start;
+}
+
+.site-search-input-shell {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 52px;
+  padding: 0 16px;
+  border: 1px solid transparent;
+  border-radius: 16px;
+  background:
+    linear-gradient(#ffffff, #ffffff) padding-box,
+    linear-gradient(135deg, #8b5cf6 0%, #ec4899 28%, #ff4d4d 52%, #f59e0b 76%, #d9ff6b 100%) border-box;
+  transition: box-shadow 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.site-search-input-shell:hover,
+.site-search-input-shell:focus-within {
+  background:
+    linear-gradient(#ffffff, #ffffff) padding-box,
+    linear-gradient(135deg, #7c3aed 0%, #ff1493 24%, #ff4d4d 48%, #ff8a00 72%, #e7ff74 100%) border-box;
+  box-shadow:
+    0 0 0 4px rgba(255, 80, 150, 0.08),
+    0 10px 24px rgba(124, 58, 237, 0.12);
+}
+
+.site-search-input-shell img {
+  width: 20px;
+  height: 20px;
+}
+
+.site-search-input-shell input {
+  flex: 1 1 auto;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: #171717;
+  font: inherit;
+  font-size: 16px;
+}
+
+.site-search-input-shell input::placeholder {
+  color: #8b8b8b;
+}
+
+.site-search-filter-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 52px;
+  padding: 0 24px;
+  border: 2px solid #1b1b1b !important;
+  border-radius: 999px;
+  background: #ffffff !important;
+  font-size: 16px;
+}
+
+.site-search-filter-icon {
+  display: inline-grid;
+  gap: 4px;
+}
+
+.site-search-filter-icon span {
+  display: block;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.site-search-filter-icon span:nth-child(1) {
+  width: 16px;
+}
+
+.site-search-filter-icon span:nth-child(2) {
+  width: 11px;
+}
+
+.site-search-filter-icon span:nth-child(3) {
+  width: 7px;
+}
+
+.site-search-close-button {
+  width: 52px;
+  height: 52px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 36px;
+  line-height: 1;
+}
+
+.site-search-results {
+  margin-top: 18px;
+  max-height: min(52vh, 520px);
+  overflow: auto;
+}
+
+.site-search-status {
+  margin: 0;
+  padding: 18px 6px 8px;
+  color: #3e3e3e;
+  font-size: 15px;
+}
+
+.site-search-status-error {
+  color: #9d1b1b;
+}
+
+.site-search-results-list {
+  display: grid;
+  gap: 12px;
+}
+
+.site-search-result-card {
+  display: grid;
+  gap: 8px;
+  padding: 18px 20px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 20px;
+  background: #ffffff;
+  color: #171717;
+  text-decoration: none;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.site-search-result-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 0, 0, 0.18);
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.08);
+}
+
+.site-search-result-card strong {
+  font-size: 17px;
+  line-height: 1.3;
+}
+
+.site-search-result-card span:last-child {
+  color: #5b5b5b;
+  font-size: 14px;
+}
+
+.site-search-result-type {
+  width: fit-content;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: #f1f1f1;
+  color: #292929 !important;
+  font-size: 12px !important;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
 @media (max-width: 1235px) {
   .site-navigation {
     display: none;
@@ -227,8 +430,6 @@
 
   .site-navigation-menu-button {
     display: inline-flex;
-    align-items: center;
-    justify-content: center;
     min-height: 44px;
   }
 
@@ -237,7 +438,52 @@
   }
 }
 
+@media (max-width: 920px) {
+  .site-header-top {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .site-header-main {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .site-search-panel {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .site-header-actions {
+    gap: 8px;
+  }
+
+  .site-console-button,
+  .site-account-button {
+    display: none;
+  }
+
+  .site-search-toolbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .site-search-close-button {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .site-search-filter-button {
+    grid-column: 1 / -1;
+    justify-self: end;
+  }
+}
+
 @media (max-width: 720px) {
+  .site-header {
+    --site-header-top-height: 0px;
+    --site-header-main-height: 72px;
+  }
+
   .site-header-top {
     display: none;
   }
@@ -272,15 +518,16 @@
     min-width: 44px;
     min-height: 44px;
     padding: 0;
-    justify-self: start;
     justify-content: center;
+    justify-self: start;
   }
 
   .site-navigation-menu-icon {
     display: inline-grid;
   }
 
-  .site-navigation {
+  .site-navigation-menu-label,
+  .site-navigation-menu-caret {
     display: none;
   }
 
@@ -296,17 +543,32 @@
     justify-content: center;
   }
 
-  .site-search-button span,
-  .site-console-button,
-  .site-account-button,
-  .site-navigation-menu-label,
-  .site-navigation-menu-caret {
+  .site-search-button span {
     display: none;
+  }
+
+  .site-search-panel {
+    padding: 16px 18px 20px;
+  }
+
+  .site-search-toolbar {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 12px;
+  }
+
+  .site-search-input-shell {
+    min-height: 48px;
+    padding-left: 14px;
+    padding-right: 14px;
+  }
+
+  .site-search-filter-button {
+    min-height: 48px;
+    padding: 0 18px;
   }
 
   .site-navigation-dropdown {
     left: 0;
-    right: auto;
-    min-width: min(320px, calc(100vw - 48px));
+    min-width: min(320px, calc(100vw - 36px));
   }
 }

--- a/src/view/common/footer/Footer.tsx
+++ b/src/view/common/footer/Footer.tsx
@@ -23,12 +23,21 @@ export function Footer() {
         hash: item.hash
     })) ?? [];
 
+    const openSearchFromFooter = () => {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth"
+        });
+
+        window.dispatchEvent(new CustomEvent("site-search:open"));
+    };
+
     return (
         <footer className="site-footer">
             <div className="site-footer-top">
                 <button className="site-footer-ride-button" type="button">Создать аккаунт RIDE</button>
 
-                <button className="site-footer-search-button" type="button">
+                <button className="site-footer-search-button" onClick={openSearchFromFooter} type="button">
                     <span>Поиск</span>
                     <img alt="" aria-hidden="true" src={searchIcon}/>
                 </button>

--- a/src/view/common/navbar/Navbar.tsx
+++ b/src/view/common/navbar/Navbar.tsx
@@ -1,9 +1,13 @@
-import {useEffect, useRef, useState} from "react";
+import {useEffect, useMemo, useRef, useState} from "react";
 import {Link, NavLink, useLocation} from "react-router-dom";
+import {searchKnowledgeBase} from "../../../api/knowledgeBaseApi";
+import type {SearchResultItem} from "../../../api/types";
 import {NavigationTree} from "../../../data/navbar/NavigationTree";
 import searchIcon from "../../../assets/home/icons/search.svg";
 import accountIcon from "../../../assets/home/icons/account.svg";
 import supportIcon from "../../../assets/home/icons/support.svg";
+
+type SearchState = "idle" | "loading" | "ready" | "error";
 
 const topLinks = [
     {label: "Помочь проекту", href: "#support", icon: supportIcon},
@@ -13,13 +17,71 @@ const topLinks = [
     {label: "Мой аккаунт", href: "#account", icon: accountIcon}
 ];
 
+function getSearchResultTitle(item: SearchResultItem): string {
+    return item.theme ?? item.title ?? "Без названия";
+}
+
+function getSearchResultDescription(item: SearchResultItem): string {
+    const fragments = [item.authors, item.published].filter(Boolean);
+    return fragments.length > 0 ? fragments.join(" · ") : "Материал портала";
+}
+
+function getSearchResultTypeLabel(item: SearchResultItem): string {
+    const normalizedType = item.type.toLowerCase();
+
+    if (normalizedType.includes("publication")) {
+        return "Публикация";
+    }
+
+    if (normalizedType.includes("work") || normalizedType.includes("diploma") || normalizedType.includes("dissertation")) {
+        return "Работа";
+    }
+
+    if (normalizedType.includes("project")) {
+        return "Проект";
+    }
+
+    return "Материал";
+}
+
+function getSearchResultTarget(item: SearchResultItem): string {
+    const normalizedType = item.type.toLowerCase();
+
+    if (normalizedType.includes("publication")) {
+        return "/publications";
+    }
+
+    if (normalizedType.includes("work") || normalizedType.includes("diploma") || normalizedType.includes("dissertation")) {
+        return "/works";
+    }
+
+    if (normalizedType.includes("project")) {
+        return "/projects";
+    }
+
+    if (normalizedType.includes("doc")) {
+        return "/docs";
+    }
+
+    return "/home";
+}
+
 export function Navbar() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const [isSearchOpen, setIsSearchOpen] = useState(false);
+    const [searchQuery, setSearchQuery] = useState("");
+    const [searchState, setSearchState] = useState<SearchState>("idle");
+    const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
+    const [searchError, setSearchError] = useState("");
     const menuRef = useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const requestIdRef = useRef(0);
     const location = useLocation();
+    const trimmedQuery = searchQuery.trim();
 
     useEffect(() => {
         setIsMenuOpen(false);
+        setIsSearchOpen(false);
     }, [location.pathname]);
 
     useEffect(() => {
@@ -29,14 +91,123 @@ export function Navbar() {
             }
         };
 
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                setIsMenuOpen(false);
+                setIsSearchOpen(false);
+            }
+        };
+
+        const handleOpenSearch = () => {
+            setIsMenuOpen(false);
+            setIsSearchOpen(true);
+        };
+
         document.addEventListener("mousedown", handleOutsideClick);
+        document.addEventListener("keydown", handleEscape);
+        window.addEventListener("site-search:open", handleOpenSearch);
+
         return () => {
             document.removeEventListener("mousedown", handleOutsideClick);
+            document.removeEventListener("keydown", handleEscape);
+            window.removeEventListener("site-search:open", handleOpenSearch);
         };
     }, []);
 
+    useEffect(() => {
+        if (!isSearchOpen) {
+            return;
+        }
+
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        inputRef.current?.focus();
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [isSearchOpen]);
+
+    useEffect(() => {
+        if (!isSearchOpen || trimmedQuery.length === 0) {
+            setSearchState("idle");
+            setSearchResults([]);
+            setSearchError("");
+            return;
+        }
+
+        const currentRequestId = ++requestIdRef.current;
+        setSearchState("loading");
+        setSearchError("");
+
+        const timeoutId = window.setTimeout(async () => {
+            try {
+                const response = await searchKnowledgeBase(trimmedQuery, 8);
+
+                if (requestIdRef.current !== currentRequestId) {
+                    return;
+                }
+
+                setSearchResults(Array.isArray(response.items) ? response.items : []);
+                setSearchState("ready");
+            } catch (error) {
+                if (requestIdRef.current !== currentRequestId) {
+                    return;
+                }
+
+                setSearchResults([]);
+                setSearchState("error");
+                setSearchError(error instanceof Error ? error.message : "Не удалось выполнить поиск");
+            }
+        }, 250);
+
+        return () => {
+            window.clearTimeout(timeoutId);
+        };
+    }, [isSearchOpen, trimmedQuery]);
+
+    const searchResultContent = useMemo(() => {
+        if (trimmedQuery.length === 0) {
+            return <p className="site-search-status">Введите запрос, чтобы найти публикации и студенческие работы.</p>;
+        }
+
+        if (searchState === "loading") {
+            return <p className="site-search-status">Ищем материалы по порталу...</p>;
+        }
+
+        if (searchState === "error") {
+            return <p className="site-search-status site-search-status-error">Не удалось выполнить поиск: {searchError}</p>;
+        }
+
+        if (!Array.isArray(searchResults) || searchResults.length === 0) {
+            return <p className="site-search-status">Ничего не найдено. Попробуйте изменить запрос.</p>;
+        }
+
+        return (
+            <div className="site-search-results-list">
+                {searchResults.map((item, index) => (
+                    <Link
+                        className="site-search-result-card"
+                        key={`${item.type}-${item.id ?? item.hash ?? index}`}
+                        onClick={() => setIsSearchOpen(false)}
+                        to={getSearchResultTarget(item)}
+                    >
+                        <span className="site-search-result-type">{getSearchResultTypeLabel(item)}</span>
+                        <strong>{getSearchResultTitle(item)}</strong>
+                        <span>{getSearchResultDescription(item)}</span>
+                    </Link>
+                ))}
+            </div>
+        );
+    }, [searchError, searchResults, searchState, trimmedQuery]);
+
+    const toggleSearch = () => {
+        setIsMenuOpen(false);
+        setIsSearchOpen((isOpen) => !isOpen);
+    };
+
     return (
-        <header className="site-header">
+        <header className={`site-header${isSearchOpen ? " site-header-search-open" : ""}`}>
             <div className="site-header-top">
                 <div className="site-header-top-links">
                     {topLinks.map((link) => (
@@ -68,7 +239,10 @@ export function Navbar() {
                         <button
                             aria-expanded={isMenuOpen}
                             className={`site-navigation-link site-navigation-menu-button${isMenuOpen ? " site-navigation-link-active" : ""}`}
-                            onClick={() => setIsMenuOpen((isOpen) => !isOpen)}
+                            onClick={() => {
+                                setIsSearchOpen(false);
+                                setIsMenuOpen((isOpen) => !isOpen);
+                            }}
                             type="button"
                         >
                             <span aria-hidden="true" className="site-navigation-menu-icon">
@@ -114,7 +288,7 @@ export function Navbar() {
                     </div>
 
                     <div className="site-header-actions">
-                        <button className="site-search-button" type="button">
+                        <button className={`site-search-button${isSearchOpen ? " site-search-button-active" : ""}`} onClick={toggleSearch} type="button">
                             <img alt="" aria-hidden="true" src={searchIcon}/>
                             <span>Поиск</span>
                         </button>
@@ -123,6 +297,49 @@ export function Navbar() {
                     </div>
                 </div>
             </div>
+
+            {isSearchOpen && (
+                <>
+                    <button aria-label="Закрыть поиск" className="site-search-backdrop" onClick={() => setIsSearchOpen(false)} type="button"/>
+
+                    <div className="site-search-panel" role="dialog" aria-label="Поиск по порталу">
+                        <div className="site-search-toolbar">
+                            <label className="site-search-input-shell">
+                                <img alt="" aria-hidden="true" src={searchIcon}/>
+                                <input
+                                    onChange={(event) => setSearchQuery(event.target.value)}
+                                    placeholder="Я ищу..."
+                                    ref={inputRef}
+                                    type="search"
+                                    value={searchQuery}
+                                />
+                            </label>
+
+                            <button className="site-search-filter-button" type="button">
+                                <span aria-hidden="true" className="site-search-filter-icon">
+                                    <span/>
+                                    <span/>
+                                    <span/>
+                                </span>
+                                <span>Фильтр</span>
+                            </button>
+
+                            <button
+                                aria-label="Закрыть поиск"
+                                className="site-search-close-button"
+                                onClick={() => setIsSearchOpen(false)}
+                                type="button"
+                            >
+                                ×
+                            </button>
+                        </div>
+
+                        <div className="site-search-results">
+                            {searchResultContent}
+                        </div>
+                    </div>
+                </>
+            )}
         </header>
     );
 }


### PR DESCRIPTION
## Summary
- add a shared search overlay in the header with desktop, compact and mobile behavior
- integrate the frontend search with the backend /api/search response format
- let the footer search button scroll to the top and open the same search experience
- update the site favicon

## Testing
- npx tsc -p tsconfig.app.json --noEmit
- npm run build