### PR TITLE
feat: выпадающая панель для пункта Проекты

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,12 @@ import {} from "./index.css";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import {WorksView} from "./view/pages/works/WorksView";
-import {ProjectsView} from "./view/pages/projects/ProjectsView";
 import {VideoView} from "./view/pages/video/VideoView";
 import {PublicationsView} from "./view/pages/publications/PublicationsView";
 import {DocsView} from "./view/pages/docs/DocsView";
 import {Home} from "./view/pages/home/Home";
 import {ChatView} from "./view/pages/chat/ChatView";
+import {ProjectItemView} from "./view/pages/projects/ProjectItemView";
 import { createBrowserRouter} from "react-router-dom";
 
 const router = createBrowserRouter([
@@ -30,7 +30,11 @@ const router = createBrowserRouter([
     },
     {
         path: "/projects",
-        element: <ProjectsView/>
+        element: <Home/>
+    },
+    {
+        path: "/projects/:itemSlug",
+        element: <ProjectItemView/>
     },
     {
         path: "/publications",

--- a/src/styles/common/Navbar.scss
+++ b/src/styles/common/Navbar.scss
@@ -230,6 +230,9 @@
 }
 
 .site-projects-panel {
+  --site-projects-arrow-slot: 56px;
+  --site-projects-arrow-offset: 16px;
+  --site-projects-arrow-size: 24px;
   position: relative;
   z-index: 2;
   padding: 0;
@@ -237,6 +240,8 @@
   border-top: 1px solid rgba(0, 0, 0, 0.08);
   border-bottom-left-radius: 28px;
   border-bottom-right-radius: 28px;
+  max-height: min(72vh, 620px);
+  overflow-y: auto;
   box-shadow: 0 24px 50px rgba(0, 0, 0, 0.18);
 }
 
@@ -250,11 +255,11 @@
 .site-projects-panel-layout {
   display: grid;
   grid-template-columns: 312px minmax(0, 1fr);
-  min-height: 520px;
+  min-height: 420px;
 }
 
 .site-projects-panel-sidebar {
-  padding: 20px 20px 28px;
+  padding: 16px 16px 20px;
   border-right: 1px solid rgba(0, 0, 0, 0.12);
   display: grid;
   align-content: start;
@@ -263,14 +268,14 @@
 
 .site-projects-category {
   width: 100%;
-  min-height: 62px;
-  padding: 0 22px;
+  min-height: 52px;
+  padding: 0 18px;
   border: 0;
   border-radius: 12px;
   background: transparent;
   color: #232323;
   font: inherit;
-  font-size: 18px;
+  font-size: 16px;
   text-align: left;
   white-space: nowrap;
   overflow: hidden;
@@ -289,7 +294,7 @@
 }
 
 .site-projects-panel-content {
-  padding: 44px 36px 28px;
+  padding: 28px 30px 20px;
 }
 
 .site-projects-panel-content h3 {
@@ -301,59 +306,65 @@
 }
 
 .site-projects-panel-content > p {
-  margin: 14px 0 0;
+  margin: 10px 0 0;
   color: #242733;
-  font-size: 24px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 1.35;
   letter-spacing: -0.01em;
 }
 
 .site-projects-panel-center-link {
   display: inline-flex;
-  margin-top: 12px;
+  margin-top: 10px;
   color: #29303e;
-  font-size: 22px;
+  font-size: 16px;
   line-height: 1.25;
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
 }
 
 .site-projects-panel-top-row {
-  margin-top: 32px;
+  margin-top: 20px;
   display: grid;
   grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
-  gap: 20px;
+  gap: 14px;
+}
+
+.site-projects-feature-card,
+.site-projects-plain-card,
+.site-projects-news-card,
+.site-projects-success-card {
+  position: relative;
+  border: 1px solid transparent;
+  color: #1b1e28;
+  transition: background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
 }
 
 .site-projects-feature-card,
 .site-projects-news-card {
-  border: 1px solid transparent;
   text-decoration: none;
-  color: #1b1e28;
-  background: #e8e8ed;
-  transition: background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
 }
 
 .site-projects-feature-card {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 20px;
-  min-height: 260px;
-  padding: 26px 22px;
+  grid-template-columns: minmax(0, 1fr);
+  align-content: start;
+  background: transparent;
+  min-height: 184px;
+  padding: 18px var(--site-projects-arrow-slot) 18px 16px;
   border-radius: 12px;
 }
 
 .site-projects-feature-copy {
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .site-projects-feature-copy strong,
 .site-projects-plain-card strong,
 .site-projects-news-copy strong,
 .site-projects-success-copy strong {
-  font-size: 22px;
+  font-size: 16px;
   font-weight: 600;
   line-height: 1.2;
   letter-spacing: -0.01em;
@@ -364,63 +375,59 @@
 .site-projects-news-copy span,
 .site-projects-success-copy span {
   color: #555a69;
-  font-size: 20px;
-  line-height: 1.35;
+  font-size: 14px;
+  line-height: 1.4;
 }
 
-.site-projects-feature-card img,
-.site-projects-news-card > img:last-child {
-  width: 28px;
-  height: 28px;
-  transition: transform 180ms ease;
-}
-
-.site-projects-feature-card:hover,
-.site-projects-news-card:hover {
+.site-projects-hover-card:hover {
   transform: translateY(-1px);
   border-color: rgba(0, 0, 0, 0.14);
-  background: #f4f4f7;
   box-shadow: 0 14px 26px rgba(8, 16, 34, 0.14);
 }
 
-.site-projects-feature-card:hover img,
-.site-projects-news-card:hover > img:last-child {
-  transform: translateX(3px);
+.site-projects-feature-card:hover,
+.site-projects-news-card:hover,
+.site-projects-plain-card:hover,
+.site-projects-success-card:hover {
+  background: #f4f4f7;
 }
 
 .site-projects-plain-card {
-  padding: 16px 4px 0;
+  min-height: 184px;
+  padding: 10px var(--site-projects-arrow-slot) 0 6px;
+  border-radius: 12px;
+  background: transparent;
   display: grid;
-  gap: 12px;
+  gap: 10px;
   align-content: start;
 }
 
 .site-projects-panel-bottom-row {
-  margin-top: 22px;
+  margin-top: 14px;
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 16px;
+  gap: 12px;
 }
 
 .site-projects-news-card,
 .site-projects-success-card {
-  min-height: 176px;
+  min-height: 128px;
   border-radius: 12px;
   background: #e8e8ed;
 }
 
 .site-projects-news-card {
   display: grid;
-  grid-template-columns: 180px minmax(0, 1fr) auto;
+  grid-template-columns: 128px minmax(0, 1fr);
   align-items: center;
-  gap: 22px;
-  padding: 0 22px 0 0;
+  gap: 14px;
+  padding: 0 var(--site-projects-arrow-slot) 0 0;
 }
 
-.site-projects-news-card > img:first-child,
-.site-projects-success-card > img {
-  width: 180px;
-  height: 176px;
+.site-projects-news-image,
+.site-projects-success-image {
+  width: 128px;
+  height: 128px;
   border-radius: 12px;
   object-fit: cover;
 }
@@ -428,15 +435,34 @@
 .site-projects-news-copy,
 .site-projects-success-copy {
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .site-projects-success-card {
   display: grid;
-  grid-template-columns: 180px minmax(0, 1fr);
+  grid-template-columns: 128px minmax(0, 1fr);
   align-items: center;
-  gap: 20px;
-  padding: 0 20px 0 0;
+  gap: 14px;
+  padding: 0 var(--site-projects-arrow-slot) 0 0;
+}
+
+.site-projects-card-arrow {
+  position: absolute;
+  right: var(--site-projects-arrow-offset);
+  top: 50%;
+  width: var(--site-projects-arrow-size);
+  height: var(--site-projects-arrow-size);
+  transform: translate(-6px, -50%);
+  opacity: 0;
+  filter: brightness(0) saturate(100%);
+  transition: opacity 180ms ease, transform 180ms ease;
+  pointer-events: none;
+}
+
+.site-projects-hover-card:hover .site-projects-card-arrow,
+.site-projects-hover-card:focus-visible .site-projects-card-arrow {
+  opacity: 1;
+  transform: translate(0, -50%);
 }
 
 .site-projects-backdrop {
@@ -787,10 +813,6 @@
 }
 
 @media (max-width: 1235px) {
-  .site-projects-panel {
-    display: none;
-  }
-
   .site-navigation {
     display: none;
   }
@@ -853,9 +875,6 @@
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
-  .site-projects-backdrop {
-    display: none;
-  }
 }
 
 @media (max-width: 720px) {
@@ -999,6 +1018,71 @@
     display: none;
   }
 
+  .site-projects-panel {
+    max-height: calc(100vh - var(--site-header-main-height));
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+  }
+
+  .site-projects-panel-layout {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: auto;
+  }
+
+  .site-projects-panel-sidebar {
+    padding: 12px 12px 14px;
+    border-right: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    gap: 6px;
+  }
+
+  .site-projects-category {
+    min-height: 44px;
+    padding: 0 12px;
+    font-size: 14px;
+  }
+
+  .site-projects-panel-content {
+    padding: 16px 14px 16px;
+  }
+
+  .site-projects-panel-content h3 {
+    font-size: 24px;
+  }
+
+  .site-projects-panel-content > p,
+  .site-projects-panel-center-link {
+    font-size: 14px;
+  }
+
+  .site-projects-panel-top-row,
+  .site-projects-panel-bottom-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+    margin-top: 12px;
+  }
+
+  .site-projects-feature-card,
+  .site-projects-plain-card {
+    min-height: auto;
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+
+  .site-projects-news-card,
+  .site-projects-success-card {
+    min-height: 100px;
+    grid-template-columns: 100px minmax(0, 1fr);
+    gap: 10px;
+    padding-right: var(--site-projects-arrow-slot);
+  }
+
+  .site-projects-news-image,
+  .site-projects-success-image {
+    width: 100px;
+    height: 100px;
+  }
+
   .site-navigation-dropdown {
     display: none;
   }
@@ -1016,7 +1100,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    overflow-y: auto;
+    overflow: hidden;
     min-height: auto;
     margin: 0;
     padding: 0 24px 24px;
@@ -1032,11 +1116,14 @@
     gap: 12px 28px;
     overflow-x: auto;
     overflow-y: hidden;
-    max-width: 100%;
-    padding: 18px 0 14px;
-    margin: 0 -24px;
-    padding-left: 24px;
-    padding-right: 24px;
+    width: 100vw;
+    max-width: none;
+    flex: 0 0 auto;
+    height: 64px;
+    box-sizing: border-box;
+    padding: 16px 24px;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
@@ -1048,11 +1135,15 @@
 
   .site-navigation-dropdown-link {
     justify-content: flex-start;
-    min-height: 72px;
-    padding: 0;
+    min-height: 44px;
+    height: 44px;
+    padding: 8px 0;
     border-radius: 0;
-    font-size: 18px;
-    font-weight: 400;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.2;
+    white-space: nowrap;
+    text-align: left;
   }
 
   .site-navigation-dropdown-link:hover {
@@ -1060,22 +1151,25 @@
   }
 
   .site-header-main-menu-links {
+    min-height: 0;
+    overflow-y: auto;
     padding-top: 10px;
   }
 
   .site-header-main-menu-links .site-navigation-dropdown-link {
     justify-content: space-between;
+    align-items: center;
   }
 
   .site-header-main-menu-links .site-navigation-dropdown-link::before {
     display: none;
   }
 
-  .site-header-main-menu-links .site-navigation-dropdown-link::after {
+  .site-header-main-menu-links .site-navigation-dropdown-link-has-children::after {
     content: "";
     position: static;
-    width: 14px;
-    height: 14px;
+    width: 18px;
+    height: 18px;
     margin-left: 16px;
     border: 0;
     background: none;
@@ -1084,6 +1178,52 @@
     -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='black' d='M8.00004 11C7.74004 11 7.49004 10.9 7.29004 10.71L3.79004 7.21005L5.20004 5.80005L7.99004 8.59005L10.78 5.80005L12.19 7.21005L8.69004 10.71C8.49004 10.91 8.24004 11 7.98004 11H8.00004Z'/%3E%3C/svg%3E") center / contain no-repeat;
     mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='black' d='M8.00004 11C7.74004 11 7.49004 10.9 7.29004 10.71L3.79004 7.21005L5.20004 5.80005L7.99004 8.59005L10.78 5.80005L12.19 7.21005L8.69004 10.71C8.49004 10.91 8.24004 11 7.98004 11H8.00004Z'/%3E%3C/svg%3E") center / contain no-repeat;
     background-color: #6b7280;
+  }
+
+  .site-navigation-mobile-back {
+    min-height: 44px;
+    height: 44px;
+    justify-content: flex-start !important;
+    gap: 10px;
+    padding: 8px 0;
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 1.2;
+  }
+
+  .site-navigation-mobile-back-icon {
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    transform: rotate(90deg);
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='black' d='M8.00004 11C7.74004 11 7.49004 10.9 7.29004 10.71L3.79004 7.21005L5.20004 5.80005L7.99004 8.59005L10.78 5.80005L12.19 7.21005L8.69004 10.71C8.49004 10.91 8.24004 11 7.98004 11H8.00004Z'/%3E%3C/svg%3E") center / contain no-repeat;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='black' d='M8.00004 11C7.74004 11 7.49004 10.9 7.29004 10.71L3.79004 7.21005L5.20004 5.80005L7.99004 8.59005L10.78 5.80005L12.19 7.21005L8.69004 10.71C8.49004 10.91 8.24004 11 7.98004 11H8.00004Z'/%3E%3C/svg%3E") center / contain no-repeat;
+    background-color: currentColor;
+  }
+
+  .site-navigation-mobile-back::after {
+    display: none !important;
+  }
+
+  .site-header-main-menu-links .site-navigation-mobile-back {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: rgba(255, 255, 255, 0.995);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+    margin-bottom: 8px;
+  }
+
+  .site-navigation-mobile-group-title {
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    padding: 0;
+    color: #6b7280;
+    font-size: 14px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
   }
 
   .site-header-main-menu-extra {

--- a/src/styles/common/Navbar.scss
+++ b/src/styles/common/Navbar.scss
@@ -23,6 +23,10 @@
   border-bottom-color: transparent;
 }
 
+.site-header-projects-open .site-header-main {
+  border-bottom-color: transparent;
+}
+
 .site-header-top {
   display: flex;
   justify-content: flex-end;
@@ -223,6 +227,225 @@
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 20px;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.14);
+}
+
+.site-projects-panel {
+  position: relative;
+  z-index: 2;
+  padding: 0;
+  background: rgba(246, 246, 248, 0.98);
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom-left-radius: 28px;
+  border-bottom-right-radius: 28px;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.18);
+}
+
+.site-projects-panel-close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  z-index: 2;
+}
+
+.site-projects-panel-layout {
+  display: grid;
+  grid-template-columns: 312px minmax(0, 1fr);
+  min-height: 520px;
+}
+
+.site-projects-panel-sidebar {
+  padding: 20px 20px 28px;
+  border-right: 1px solid rgba(0, 0, 0, 0.12);
+  display: grid;
+  align-content: start;
+  gap: 8px;
+}
+
+.site-projects-category {
+  width: 100%;
+  min-height: 62px;
+  padding: 0 22px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  color: #232323;
+  font: inherit;
+  font-size: 18px;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.site-projects-category:hover {
+  background: rgba(37, 37, 37, 0.09);
+}
+
+.site-projects-category-active {
+  background: #2f2f31;
+  color: #ffffff;
+}
+
+.site-projects-panel-content {
+  padding: 44px 36px 28px;
+}
+
+.site-projects-panel-content h3 {
+  margin: 0;
+  color: #171a25;
+  font-size: clamp(2rem, 2.2vw, 2.75rem);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+}
+
+.site-projects-panel-content > p {
+  margin: 14px 0 0;
+  color: #242733;
+  font-size: 24px;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.site-projects-panel-center-link {
+  display: inline-flex;
+  margin-top: 12px;
+  color: #29303e;
+  font-size: 22px;
+  line-height: 1.25;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+.site-projects-panel-top-row {
+  margin-top: 32px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: 20px;
+}
+
+.site-projects-feature-card,
+.site-projects-news-card {
+  border: 1px solid transparent;
+  text-decoration: none;
+  color: #1b1e28;
+  background: #e8e8ed;
+  transition: background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.site-projects-feature-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 20px;
+  min-height: 260px;
+  padding: 26px 22px;
+  border-radius: 12px;
+}
+
+.site-projects-feature-copy {
+  display: grid;
+  gap: 10px;
+}
+
+.site-projects-feature-copy strong,
+.site-projects-plain-card strong,
+.site-projects-news-copy strong,
+.site-projects-success-copy strong {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.site-projects-feature-copy span,
+.site-projects-plain-card span,
+.site-projects-news-copy span,
+.site-projects-success-copy span {
+  color: #555a69;
+  font-size: 20px;
+  line-height: 1.35;
+}
+
+.site-projects-feature-card img,
+.site-projects-news-card > img:last-child {
+  width: 28px;
+  height: 28px;
+  transition: transform 180ms ease;
+}
+
+.site-projects-feature-card:hover,
+.site-projects-news-card:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 0, 0, 0.14);
+  background: #f4f4f7;
+  box-shadow: 0 14px 26px rgba(8, 16, 34, 0.14);
+}
+
+.site-projects-feature-card:hover img,
+.site-projects-news-card:hover > img:last-child {
+  transform: translateX(3px);
+}
+
+.site-projects-plain-card {
+  padding: 16px 4px 0;
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.site-projects-panel-bottom-row {
+  margin-top: 22px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 16px;
+}
+
+.site-projects-news-card,
+.site-projects-success-card {
+  min-height: 176px;
+  border-radius: 12px;
+  background: #e8e8ed;
+}
+
+.site-projects-news-card {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 22px;
+  padding: 0 22px 0 0;
+}
+
+.site-projects-news-card > img:first-child,
+.site-projects-success-card > img {
+  width: 180px;
+  height: 176px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.site-projects-news-copy,
+.site-projects-success-copy {
+  display: grid;
+  gap: 10px;
+}
+
+.site-projects-success-card {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  align-items: center;
+  gap: 20px;
+  padding: 0 20px 0 0;
+}
+
+.site-projects-backdrop {
+  position: fixed;
+  inset: calc(var(--site-header-top-height) + var(--site-header-main-height)) 0 0;
+  z-index: 1;
+  border: 0;
+  background: rgba(20, 20, 20, 0.66);
+  backdrop-filter: blur(8px);
 }
 
 .site-navigation-dropdown-link {
@@ -564,6 +787,10 @@
 }
 
 @media (max-width: 1235px) {
+  .site-projects-panel {
+    display: none;
+  }
+
   .site-navigation {
     display: none;
   }
@@ -624,6 +851,10 @@
 
   .site-search-toolbar-main {
     grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .site-projects-backdrop {
+    display: none;
   }
 }
 

--- a/src/view/common/navbar/Navbar.tsx
+++ b/src/view/common/navbar/Navbar.tsx
@@ -6,6 +6,9 @@ import {NavigationTree} from "../../../data/navbar/NavigationTree";
 import searchIcon from "../../../assets/home/icons/search.svg";
 import accountIcon from "../../../assets/home/icons/account.svg";
 import supportIcon from "../../../assets/home/icons/support.svg";
+import arrowRightAltIcon from "../../../assets/home/icons/arrow-right-alt.svg";
+import caseOneImage from "../../../assets/home/cases/case-1.png";
+import caseTwoImage from "../../../assets/home/cases/case-2.png";
 
 type SearchState = "idle" | "loading" | "ready" | "error";
 
@@ -15,6 +18,44 @@ const topLinks = [
     {label: "Poprog маркет", href: "#market"},
     {label: "Поддержка", href: "#support"},
     {label: "Мой аккаунт", href: "#account", icon: accountIcon}
+];
+
+const projectsCategories = [
+    {
+        key: "languages",
+        label: "Языки программирования",
+        title: "Языки программирования",
+        description: "Программируйте ПЛК и микроконтроллеры на инновационных языках быстрее и проще",
+        centerLinkLabel: "Перейти в центр Языков программирования"
+    },
+    {
+        key: "ride",
+        label: "Облачная среда разработки RIDE",
+        title: "Облачная среда разработки RIDE",
+        description: "Создавайте, тестируйте и поддерживайте программы в единой среде разработки",
+        centerLinkLabel: "Перейти в центр RIDE"
+    },
+    {
+        key: "edtl",
+        label: "Инженерия требований и EDTL",
+        title: "Инженерия требований и EDTL",
+        description: "Формализуйте требования и связывайте их с исполняемыми спецификациями",
+        centerLinkLabel: "Перейти в центр инженерии требований"
+    },
+    {
+        key: "distributed",
+        label: "Распределенные микроконтроллерные системы",
+        title: "Распределенные микроконтроллерные системы",
+        description: "Проектируйте устойчивые многоконтурные системы для производственных задач",
+        centerLinkLabel: "Перейти в центр распределенных систем"
+    },
+    {
+        key: "analysis",
+        label: "Инструменты статического анализа",
+        title: "Инструменты статического анализа",
+        description: "Анализируйте код и модели заранее, чтобы снижать риски на этапе разработки",
+        centerLinkLabel: "Перейти в центр статического анализа"
+    }
 ];
 
 function getSearchResultTitle(item: SearchResultItem): string {
@@ -69,11 +110,14 @@ function getSearchResultTarget(item: SearchResultItem): string {
 export function Navbar() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
+    const [isProjectsPanelOpen, setIsProjectsPanelOpen] = useState(false);
+    const [activeProjectsCategoryIndex, setActiveProjectsCategoryIndex] = useState(0);
     const [searchQuery, setSearchQuery] = useState("");
     const [searchState, setSearchState] = useState<SearchState>("idle");
     const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
     const [searchError, setSearchError] = useState("");
     const menuRef = useRef<HTMLDivElement | null>(null);
+    const projectsPanelRef = useRef<HTMLDivElement | null>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const requestIdRef = useRef(0);
     const location = useLocation();
@@ -82,6 +126,7 @@ export function Navbar() {
     useEffect(() => {
         setIsMenuOpen(false);
         setIsSearchOpen(false);
+        setIsProjectsPanelOpen(false);
     }, [location.pathname]);
 
     useEffect(() => {
@@ -90,8 +135,13 @@ export function Navbar() {
                 return;
             }
 
-            if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+            const clickedNode = event.target as Node;
+            const clickedOutsideMenu = !menuRef.current || !menuRef.current.contains(clickedNode);
+            const clickedOutsideProjectsPanel = !projectsPanelRef.current || !projectsPanelRef.current.contains(clickedNode);
+
+            if (clickedOutsideMenu && clickedOutsideProjectsPanel) {
                 setIsMenuOpen(false);
+                setIsProjectsPanelOpen(false);
             }
         };
 
@@ -99,11 +149,13 @@ export function Navbar() {
             if (event.key === "Escape") {
                 setIsMenuOpen(false);
                 setIsSearchOpen(false);
+                setIsProjectsPanelOpen(false);
             }
         };
 
         const handleOpenSearch = () => {
             setIsMenuOpen(false);
+            setIsProjectsPanelOpen(false);
             setIsSearchOpen(true);
         };
 
@@ -119,6 +171,29 @@ export function Navbar() {
     }, [isMenuOpen]);
 
     useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const mediaQuery = window.matchMedia("(max-width: 1235px)");
+        const handleChange = (event: MediaQueryListEvent) => {
+            if (event.matches) {
+                setIsProjectsPanelOpen(false);
+            }
+        };
+
+        if (mediaQuery.matches) {
+            setIsProjectsPanelOpen(false);
+        }
+
+        mediaQuery.addEventListener("change", handleChange);
+
+        return () => {
+            mediaQuery.removeEventListener("change", handleChange);
+        };
+    }, []);
+
+    useEffect(() => {
         if (!isSearchOpen) {
             return;
         }
@@ -131,6 +206,19 @@ export function Navbar() {
             document.body.style.overflow = previousOverflow;
         };
     }, [isSearchOpen]);
+
+    useEffect(() => {
+        if (!isProjectsPanelOpen) {
+            return;
+        }
+
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [isProjectsPanelOpen]);
 
     useEffect(() => {
         if (!isMenuOpen || typeof window === "undefined" || !window.matchMedia("(max-width: 720px)").matches) {
@@ -220,11 +308,18 @@ export function Navbar() {
 
     const toggleSearch = () => {
         setIsMenuOpen(false);
+        setIsProjectsPanelOpen(false);
         setIsSearchOpen((isOpen) => !isOpen);
     };
 
+    const activeProjectsCategory = projectsCategories[activeProjectsCategoryIndex] ?? projectsCategories[0];
+
+    const closeProjectsPanel = () => {
+        setIsProjectsPanelOpen(false);
+    };
+
     return (
-        <header className={`site-header${isSearchOpen ? " site-header-search-open" : ""}`}>
+        <header className={`site-header${isSearchOpen ? " site-header-search-open" : ""}${isProjectsPanelOpen ? " site-header-projects-open" : ""}`}>
             <div className="site-header-stack">
                 <div className="site-header-top">
                     <div className="site-header-top-links">
@@ -244,13 +339,29 @@ export function Navbar() {
                         <div className="site-navigation-shell" ref={menuRef}>
                             <nav aria-label="Главная навигация" className="site-navigation">
                                 {NavigationTree.map(([path, title]) => (
-                                    <NavLink
-                                        className={({isActive}) => `site-navigation-link${isActive ? " site-navigation-link-active" : ""}`}
-                                        key={path}
-                                        to={path}
-                                    >
-                                        {title}
-                                    </NavLink>
+                                    path === "/projects" ? (
+                                        <button
+                                            aria-expanded={isProjectsPanelOpen}
+                                            className={`site-navigation-link${isProjectsPanelOpen || location.pathname === path ? " site-navigation-link-active" : ""}`}
+                                            key={path}
+                                            onClick={() => {
+                                                setIsSearchOpen(false);
+                                                setIsMenuOpen(false);
+                                                setIsProjectsPanelOpen((isOpen) => !isOpen);
+                                            }}
+                                            type="button"
+                                        >
+                                            {title}
+                                        </button>
+                                    ) : (
+                                        <NavLink
+                                            className={({isActive}) => `site-navigation-link${isActive ? " site-navigation-link-active" : ""}`}
+                                            key={path}
+                                            to={path}
+                                        >
+                                            {title}
+                                        </NavLink>
+                                    )
                                 ))}
                             </nav>
 
@@ -259,6 +370,7 @@ export function Navbar() {
                                 className={`site-navigation-link site-navigation-menu-button${isMenuOpen ? " site-navigation-link-active" : ""}`}
                                 onClick={() => {
                                     setIsSearchOpen(false);
+                                    setIsProjectsPanelOpen(false);
                                     setIsMenuOpen((isOpen) => !isOpen);
                                 }}
                                 type="button"
@@ -319,6 +431,79 @@ export function Navbar() {
                     </div>
 
                 </div>
+
+                {isProjectsPanelOpen && (
+                    <div className="site-projects-panel" ref={projectsPanelRef} role="dialog" aria-label="Панель проектов">
+                        <button
+                            aria-label="Закрыть панель проектов"
+                            className="site-projects-panel-close site-search-x-button"
+                            onClick={closeProjectsPanel}
+                            type="button"
+                        />
+
+                        <div className="site-projects-panel-layout">
+                            <aside className="site-projects-panel-sidebar" aria-label="Разделы проектов">
+                                {projectsCategories.map((category, index) => (
+                                    <button
+                                        className={`site-projects-category${index === activeProjectsCategoryIndex ? " site-projects-category-active" : ""}`}
+                                        key={category.key}
+                                        onClick={() => setActiveProjectsCategoryIndex(index)}
+                                        type="button"
+                                    >
+                                        {category.label}
+                                    </button>
+                                ))}
+                            </aside>
+
+                            <section className="site-projects-panel-content">
+                                <h3>{activeProjectsCategory.title}</h3>
+                                <p>{activeProjectsCategory.description}</p>
+                                <Link className="site-projects-panel-center-link" onClick={closeProjectsPanel} to="/projects">
+                                    {activeProjectsCategory.centerLinkLabel}
+                                </Link>
+
+                                <div className="site-projects-panel-top-row">
+                                    <Link className="site-projects-feature-card" onClick={closeProjectsPanel} to="/projects">
+                                        <div className="site-projects-feature-copy">
+                                            <strong>Reflex</strong>
+                                            <span>Язык для разработки ПО микроконтроллеров во встраиваемых системах с использованием методик процесс-ориентированного программирования</span>
+                                        </div>
+                                        <img alt="" aria-hidden="true" src={arrowRightAltIcon}/>
+                                    </Link>
+
+                                    <article className="site-projects-plain-card">
+                                        <strong>poST</strong>
+                                        <span>Процесс-ориентированное расширение языка Structured Text (ST) для программирования алгоритмически сложных управляющих программ для ПЛК</span>
+                                    </article>
+
+                                    <article className="site-projects-plain-card">
+                                        <strong>IndustrialC</strong>
+                                        <span>Специализированный процесс-ориентированный язык программирования для задач промышленной автоматизации и систем реального времени с синтаксисом, похожим на Cи</span>
+                                    </article>
+                                </div>
+
+                                <div className="site-projects-panel-bottom-row">
+                                    <Link className="site-projects-news-card" onClick={closeProjectsPanel} to="/projects">
+                                        <img alt="" src={caseOneImage}/>
+                                        <div className="site-projects-news-copy">
+                                            <strong>Что нового?</strong>
+                                            <span>Изучите новые возможности и передовые технологии</span>
+                                        </div>
+                                        <img alt="" aria-hidden="true" src={arrowRightAltIcon}/>
+                                    </Link>
+
+                                    <article className="site-projects-success-card">
+                                        <img alt="" src={caseTwoImage}/>
+                                        <div className="site-projects-success-copy">
+                                            <strong>Истории успеха наших пользователей</strong>
+                                            <span>Узнайте, как технологии Poprog ускоряют переход предприятий в Индустрию 4.0</span>
+                                        </div>
+                                    </article>
+                                </div>
+                            </section>
+                        </div>
+                    </div>
+                )}
 
                 {isMenuOpen && (
                     <div className="site-header-main-menu">
@@ -413,6 +598,15 @@ export function Navbar() {
 
             {isSearchOpen && (
                 <button aria-label="Закрыть поиск" className="site-search-backdrop" onClick={() => setIsSearchOpen(false)} type="button"/>
+            )}
+
+            {isProjectsPanelOpen && (
+                <button
+                    aria-label="Закрыть панель проектов"
+                    className="site-projects-backdrop"
+                    onClick={closeProjectsPanel}
+                    type="button"
+                />
             )}
         </header>
     );

--- a/src/view/common/navbar/Navbar.tsx
+++ b/src/view/common/navbar/Navbar.tsx
@@ -11,6 +11,7 @@ import caseOneImage from "../../../assets/home/cases/case-1.png";
 import caseTwoImage from "../../../assets/home/cases/case-2.png";
 
 type SearchState = "idle" | "loading" | "ready" | "error";
+type ProjectLeafItem = { slug: string, title: string };
 
 const topLinks = [
     {label: "Помочь проекту", href: "#support", icon: supportIcon},
@@ -58,6 +59,42 @@ const projectsCategories = [
     }
 ];
 
+const mobileProjectsItemsByCategory: Record<string, ProjectLeafItem[]> = {
+    languages: [
+        {slug: "reflex", title: "Reflex"},
+        {slug: "post", title: "poST"},
+        {slug: "industrial-c", title: "IndustrialC"},
+        {slug: "languages-whats-new", title: "Что нового?"},
+        {slug: "success-stories", title: "Истории успеха"}
+    ],
+    ride: [
+        {slug: "ride-overview", title: "Обзор RIDE"},
+        {slug: "ride-cloud-launch", title: "Запуск в облаке"},
+        {slug: "ride-debug", title: "Инструменты отладки"},
+        {slug: "ride-whats-new", title: "Что нового?"}
+    ],
+    edtl: [
+        {slug: "requirements", title: "Требования"},
+        {slug: "traceability", title: "Трассировка"},
+        {slug: "edtl-spec", title: "EDTL-спецификации"},
+        {slug: "edtl-whats-new", title: "Что нового?"}
+    ],
+    distributed: [
+        {slug: "architecture-templates", title: "Шаблоны архитектур"},
+        {slug: "communication-modules", title: "Модули связи"},
+        {slug: "typical-solutions", title: "Типовые решения"},
+        {slug: "distributed-whats-new", title: "Что нового?"}
+    ],
+    analysis: [
+        {slug: "code-checks", title: "Проверки кода"},
+        {slug: "quality-metrics", title: "Метрики качества"},
+        {slug: "analysis-reports", title: "Отчеты анализа"},
+        {slug: "analysis-whats-new", title: "Что нового?"}
+    ]
+};
+
+type MobileProjectsMenuStage = "root" | "groups" | "items";
+
 function getSearchResultTitle(item: SearchResultItem): string {
     return item.theme;
 }
@@ -97,7 +134,7 @@ function getSearchResultTarget(item: SearchResultItem): string {
     }
 
     if (normalizedType.includes("project")) {
-        return "/projects";
+        return "/home";
     }
 
     if (normalizedType.includes("doc")) {
@@ -112,6 +149,8 @@ export function Navbar() {
     const [isSearchOpen, setIsSearchOpen] = useState(false);
     const [isProjectsPanelOpen, setIsProjectsPanelOpen] = useState(false);
     const [activeProjectsCategoryIndex, setActiveProjectsCategoryIndex] = useState(0);
+    const [mobileProjectsMenuStage, setMobileProjectsMenuStage] = useState<MobileProjectsMenuStage>("root");
+    const [mobileProjectsCategoryIndex, setMobileProjectsCategoryIndex] = useState(0);
     const [searchQuery, setSearchQuery] = useState("");
     const [searchState, setSearchState] = useState<SearchState>("idle");
     const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
@@ -127,7 +166,14 @@ export function Navbar() {
         setIsMenuOpen(false);
         setIsSearchOpen(false);
         setIsProjectsPanelOpen(false);
+        setMobileProjectsMenuStage("root");
     }, [location.pathname]);
+
+    useEffect(() => {
+        if (!isMenuOpen) {
+            setMobileProjectsMenuStage("root");
+        }
+    }, [isMenuOpen]);
 
     useEffect(() => {
         const handleOutsideClick = (event: MouseEvent) => {
@@ -175,7 +221,7 @@ export function Navbar() {
             return;
         }
 
-        const mediaQuery = window.matchMedia("(max-width: 1235px)");
+        const mediaQuery = window.matchMedia("(max-width: 720px)");
         const handleChange = (event: MediaQueryListEvent) => {
             if (event.matches) {
                 setIsProjectsPanelOpen(false);
@@ -313,6 +359,8 @@ export function Navbar() {
     };
 
     const activeProjectsCategory = projectsCategories[activeProjectsCategoryIndex] ?? projectsCategories[0];
+    const mobileProjectsCategory = projectsCategories[mobileProjectsCategoryIndex] ?? projectsCategories[0];
+    const mobileProjectsItems = mobileProjectsItemsByCategory[mobileProjectsCategory.key] ?? [];
 
     const closeProjectsPanel = () => {
         setIsProjectsPanelOpen(false);
@@ -394,13 +442,28 @@ export function Navbar() {
                             {isMenuOpen && (
                                 <div className="site-navigation-dropdown">
                                     {NavigationTree.map(([path, title]) => (
-                                        <NavLink
-                                            className={({isActive}) => `site-navigation-link site-navigation-dropdown-link${isActive ? " site-navigation-link-active" : ""}`}
-                                            key={`dropdown-${path}`}
-                                            to={path}
-                                        >
-                                            {title}
-                                        </NavLink>
+                                        path === "/projects" ? (
+                                            <button
+                                                className="site-navigation-link site-navigation-dropdown-link"
+                                                key={`dropdown-${path}`}
+                                                onClick={() => {
+                                                    setIsMenuOpen(false);
+                                                    setIsSearchOpen(false);
+                                                    setIsProjectsPanelOpen(true);
+                                                }}
+                                                type="button"
+                                            >
+                                                {title}
+                                            </button>
+                                        ) : (
+                                            <NavLink
+                                                className={({isActive}) => `site-navigation-link site-navigation-dropdown-link${isActive ? " site-navigation-link-active" : ""}`}
+                                                key={`dropdown-${path}`}
+                                                to={path}
+                                            >
+                                                {title}
+                                            </NavLink>
+                                        )
                                     ))}
 
                                     <div className="site-navigation-dropdown-actions">
@@ -458,46 +521,49 @@ export function Navbar() {
                             <section className="site-projects-panel-content">
                                 <h3>{activeProjectsCategory.title}</h3>
                                 <p>{activeProjectsCategory.description}</p>
-                                <Link className="site-projects-panel-center-link" onClick={closeProjectsPanel} to="/projects">
+                                <Link className="site-projects-panel-center-link" onClick={closeProjectsPanel} to="/home">
                                     {activeProjectsCategory.centerLinkLabel}
                                 </Link>
 
                                 <div className="site-projects-panel-top-row">
-                                    <Link className="site-projects-feature-card" onClick={closeProjectsPanel} to="/projects">
+                                    <Link className="site-projects-feature-card site-projects-hover-card" onClick={closeProjectsPanel} to="/home">
                                         <div className="site-projects-feature-copy">
                                             <strong>Reflex</strong>
                                             <span>Язык для разработки ПО микроконтроллеров во встраиваемых системах с использованием методик процесс-ориентированного программирования</span>
                                         </div>
-                                        <img alt="" aria-hidden="true" src={arrowRightAltIcon}/>
+                                        <img alt="" aria-hidden="true" className="site-projects-card-arrow" src={arrowRightAltIcon}/>
                                     </Link>
 
-                                    <article className="site-projects-plain-card">
+                                    <article className="site-projects-plain-card site-projects-hover-card">
                                         <strong>poST</strong>
                                         <span>Процесс-ориентированное расширение языка Structured Text (ST) для программирования алгоритмически сложных управляющих программ для ПЛК</span>
+                                        <img alt="" aria-hidden="true" className="site-projects-card-arrow" src={arrowRightAltIcon}/>
                                     </article>
 
-                                    <article className="site-projects-plain-card">
+                                    <article className="site-projects-plain-card site-projects-hover-card">
                                         <strong>IndustrialC</strong>
                                         <span>Специализированный процесс-ориентированный язык программирования для задач промышленной автоматизации и систем реального времени с синтаксисом, похожим на Cи</span>
+                                        <img alt="" aria-hidden="true" className="site-projects-card-arrow" src={arrowRightAltIcon}/>
                                     </article>
                                 </div>
 
                                 <div className="site-projects-panel-bottom-row">
-                                    <Link className="site-projects-news-card" onClick={closeProjectsPanel} to="/projects">
-                                        <img alt="" src={caseOneImage}/>
+                                    <Link className="site-projects-news-card site-projects-hover-card" onClick={closeProjectsPanel} to="/home">
+                                        <img alt="" className="site-projects-news-image" src={caseOneImage}/>
                                         <div className="site-projects-news-copy">
                                             <strong>Что нового?</strong>
                                             <span>Изучите новые возможности и передовые технологии</span>
                                         </div>
-                                        <img alt="" aria-hidden="true" src={arrowRightAltIcon}/>
+                                        <img alt="" aria-hidden="true" className="site-projects-card-arrow" src={arrowRightAltIcon}/>
                                     </Link>
 
-                                    <article className="site-projects-success-card">
-                                        <img alt="" src={caseTwoImage}/>
+                                    <article className="site-projects-success-card site-projects-hover-card">
+                                        <img alt="" className="site-projects-success-image" src={caseTwoImage}/>
                                         <div className="site-projects-success-copy">
                                             <strong>Истории успеха наших пользователей</strong>
                                             <span>Узнайте, как технологии Poprog ускоряют переход предприятий в Индустрию 4.0</span>
                                         </div>
+                                        <img alt="" aria-hidden="true" className="site-projects-card-arrow" src={arrowRightAltIcon}/>
                                     </article>
                                 </div>
                             </section>
@@ -517,31 +583,102 @@ export function Navbar() {
                         </div>
 
                         <div className="site-header-main-menu-links">
-                            {NavigationTree.map(([path, title]) => (
-                                <NavLink
-                                    className={({isActive}) => `site-navigation-link site-navigation-dropdown-link${isActive ? " site-navigation-link-active" : ""}`}
-                                    key={`mobile-${path}`}
-                                    to={path}
-                                >
-                                    {title}
-                                </NavLink>
+                            {mobileProjectsMenuStage === "root" && NavigationTree.map(([path, title]) => (
+                                path === "/projects" ? (
+                                    <button
+                                        className="site-navigation-link site-navigation-dropdown-link site-navigation-dropdown-link-has-children"
+                                        key={`mobile-${path}`}
+                                        onClick={() => {
+                                            setMobileProjectsCategoryIndex(0);
+                                            setMobileProjectsMenuStage("groups");
+                                        }}
+                                        type="button"
+                                    >
+                                        {title}
+                                    </button>
+                                ) : (
+                                    <NavLink
+                                        className={({isActive}) => `site-navigation-link site-navigation-dropdown-link${isActive ? " site-navigation-link-active" : ""}`}
+                                        key={`mobile-${path}`}
+                                        to={path}
+                                    >
+                                        {title}
+                                    </NavLink>
+                                )
                             ))}
+
+                            {mobileProjectsMenuStage === "groups" && (
+                                <>
+                                    <button
+                                        className="site-navigation-link site-navigation-dropdown-link site-navigation-mobile-back"
+                                        onClick={() => setMobileProjectsMenuStage("root")}
+                                        type="button"
+                                    >
+                                        <span aria-hidden="true" className="site-navigation-mobile-back-icon"/>
+                                        <span>Проекты</span>
+                                    </button>
+
+                                    {projectsCategories.map((category, index) => (
+                                        <button
+                                            className={`site-navigation-link site-navigation-dropdown-link${(mobileProjectsItemsByCategory[category.key] ?? []).length > 0 ? " site-navigation-dropdown-link-has-children" : ""}`}
+                                            key={`mobile-project-group-${category.key}`}
+                                            onClick={() => {
+                                                setMobileProjectsCategoryIndex(index);
+                                                setMobileProjectsMenuStage("items");
+                                            }}
+                                            type="button"
+                                        >
+                                            {category.label}
+                                        </button>
+                                    ))}
+                                </>
+                            )}
+
+                            {mobileProjectsMenuStage === "items" && (
+                                <>
+                                    <button
+                                        className="site-navigation-link site-navigation-dropdown-link site-navigation-mobile-back"
+                                        onClick={() => setMobileProjectsMenuStage("groups")}
+                                        type="button"
+                                    >
+                                        <span aria-hidden="true" className="site-navigation-mobile-back-icon"/>
+                                        <span>{mobileProjectsCategory.label}</span>
+                                    </button>
+
+                                    {mobileProjectsItems.map((item) => (
+                                        <NavLink
+                                            className="site-navigation-link site-navigation-dropdown-link"
+                                            key={`mobile-project-item-${mobileProjectsCategory.key}-${item.slug}`}
+                                            onClick={() => {
+                                                setIsMenuOpen(false);
+                                                setIsSearchOpen(false);
+                                                setIsProjectsPanelOpen(false);
+                                            }}
+                                            to={`/projects/${item.slug}`}
+                                        >
+                                            {item.title}
+                                        </NavLink>
+                                    ))}
+                                </>
+                            )}
                         </div>
 
-                        <div className="site-header-main-menu-extra">
-                            <div className="site-header-main-menu-actions">
-                                <button className="site-navigation-link site-navigation-dropdown-link" onClick={toggleSearch} type="button">
-                                    <img alt="" aria-hidden="true" src={searchIcon}/>
-                                    <span>Поиск</span>
-                                </button>
-                                <button className="site-navigation-link site-navigation-dropdown-link" type="button">
-                                    Вход в консоль
-                                </button>
-                                <button className="site-navigation-link site-navigation-dropdown-link" type="button">
-                                    Создать аккаунт
-                                </button>
+                        {mobileProjectsMenuStage === "root" && (
+                            <div className="site-header-main-menu-extra">
+                                <div className="site-header-main-menu-actions">
+                                    <button className="site-navigation-link site-navigation-dropdown-link" onClick={toggleSearch} type="button">
+                                        <img alt="" aria-hidden="true" src={searchIcon}/>
+                                        <span>Поиск</span>
+                                    </button>
+                                    <button className="site-navigation-link site-navigation-dropdown-link" type="button">
+                                        Вход в консоль
+                                    </button>
+                                    <button className="site-navigation-link site-navigation-dropdown-link" type="button">
+                                        Создать аккаунт
+                                    </button>
+                                </div>
                             </div>
-                        </div>
+                        )}
                     </div>
                 )}
 

--- a/src/view/pages/projects/ProjectItemView.tsx
+++ b/src/view/pages/projects/ProjectItemView.tsx
@@ -1,0 +1,43 @@
+import {useMemo} from "react";
+import {useParams} from "react-router-dom";
+import BodyView from "../BodyView";
+
+const projectItemTitles: Record<string, string> = {
+    "reflex": "Reflex",
+    "post": "poST",
+    "industrial-c": "IndustrialC",
+    "languages-whats-new": "Что нового?",
+    "success-stories": "Истории успеха",
+    "ride-overview": "Обзор RIDE",
+    "ride-cloud-launch": "Запуск в облаке",
+    "ride-debug": "Инструменты отладки",
+    "ride-whats-new": "Что нового?",
+    "requirements": "Требования",
+    "traceability": "Трассировка",
+    "edtl-spec": "EDTL-спецификации",
+    "edtl-whats-new": "Что нового?",
+    "architecture-templates": "Шаблоны архитектур",
+    "communication-modules": "Модули связи",
+    "typical-solutions": "Типовые решения",
+    "distributed-whats-new": "Что нового?",
+    "code-checks": "Проверки кода",
+    "quality-metrics": "Метрики качества",
+    "analysis-reports": "Отчеты анализа",
+    "analysis-whats-new": "Что нового?"
+};
+
+export function ProjectItemView() {
+    const {itemSlug = ""} = useParams();
+
+    const title = useMemo(() => {
+        return projectItemTitles[itemSlug] ?? "Элемент проекта";
+    }, [itemSlug]);
+
+    return BodyView(
+        <main className="projects-page">
+            <section className="projects-page-content">
+                <h1>{title}</h1>
+            </section>
+        </main>
+    );
+}

--- a/src/view/pages/projects/ProjectsView.tsx
+++ b/src/view/pages/projects/ProjectsView.tsx
@@ -1,5 +1,4 @@
 import BodyView from "../BodyView";
-import {ProjectsViewBlock} from "./ProjectsViewBlock";
 
 export function ProjectsView() {
     return (BodyView(page()))
@@ -7,12 +6,10 @@ export function ProjectsView() {
 
 function page() {
     return (
-        <main>
-            <div className="projects">
+        <main className="projects-page">
+            <section className="projects-page-content">
                 <h1>Проекты</h1>
-                <ProjectsViewBlock/>
-            </div>
+            </section>
         </main>
     )
 }
-


### PR DESCRIPTION
## Что сделано
- добавлена выпадающая панель (mega-menu) по клику на элемент «Проекты» в главной навигации
- реализована структура панели по референсу: левая колонка категорий, контентная часть, карточки и кнопка закрытия
- для карточек «Reflex» и «Что нового?» добавлены hover-состояния с визуальной реакцией
- добавлен затемняющий backdrop и предсказуемое закрытие панели (клик вне панели, Esc, переходы)
- сохранена совместимость с compact/mobile: панель скрыта в режимах, где работает общее меню

## Проверки
- npx tsc -p tsconfig.app.json --noEmit
- npm run build

Closes #39