### PR TITLE
feat: improve search external link navigation flow

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import {DocsView} from "./view/pages/docs/DocsView";
 import {Home} from "./view/pages/home/Home";
 import {ChatView} from "./view/pages/chat/ChatView";
 import {ProjectItemView} from "./view/pages/projects/ProjectItemView";
+import {NotFoundView} from "./view/pages/not-found/NotFoundView";
 import { createBrowserRouter} from "react-router-dom";
 
 const router = createBrowserRouter([
@@ -47,6 +48,10 @@ const router = createBrowserRouter([
     {
         path: "/chat",
         element: <ChatView/>
+    },
+    {
+        path: "/not-found",
+        element: <NotFoundView/>
     },
     {
         path: "*",

--- a/src/styles/common/Navbar.scss
+++ b/src/styles/common/Navbar.scss
@@ -767,6 +767,74 @@
   color: #9d1b1b;
 }
 
+.site-external-resource-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  border: 0;
+  background: rgba(16, 16, 16, 0.52);
+  backdrop-filter: blur(4px);
+}
+
+.site-external-resource-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 121;
+  width: min(560px, calc(100vw - 32px));
+  padding: 24px;
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 28px 64px rgba(0, 0, 0, 0.28);
+}
+
+.site-external-resource-modal h3 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.2;
+}
+
+.site-external-resource-modal p {
+  margin: 12px 0 0;
+  color: #4b4b4b;
+}
+
+.site-external-resource-url {
+  margin-top: 8px !important;
+  word-break: break-all;
+  color: #151515 !important;
+}
+
+.site-external-resource-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.site-external-resource-cancel,
+.site-external-resource-confirm {
+  min-height: 42px;
+  padding: 0 18px;
+  border-radius: 12px;
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.site-external-resource-cancel {
+  border: 1px solid #c7c7c7;
+  background: #ffffff;
+  color: #222222;
+}
+
+.site-external-resource-confirm {
+  border: 1px solid #171717;
+  background: #171717;
+  color: #ffffff;
+}
+
 .site-search-results-list {
   display: grid;
   gap: 12px;
@@ -775,11 +843,15 @@
 .site-search-result-card {
   display: grid;
   gap: 8px;
+  width: 100%;
   padding: 18px 20px;
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 20px;
   background: #ffffff;
   color: #171717;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
   text-decoration: none;
   transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
 }

--- a/src/view/common/navbar/Navbar.tsx
+++ b/src/view/common/navbar/Navbar.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useMemo, useRef, useState} from "react";
 import {Link, NavLink, useLocation} from "react-router-dom";
 import {searchKnowledgeBase} from "../../../api/knowledgeBaseApi";
+import {apiBaseUrl} from "../../../api/config";
 import type {SearchResultItem} from "../../../api/types";
 import {NavigationTree} from "../../../data/navbar/NavigationTree";
 import searchIcon from "../../../assets/home/icons/search.svg";
@@ -122,7 +123,7 @@ function getSearchResultTypeLabel(item: SearchResultItem): string {
     return "Материал";
 }
 
-function getSearchResultTarget(item: SearchResultItem): string {
+function getSearchResultFallbackTarget(item: SearchResultItem): string {
     const normalizedType = item.type.toLowerCase();
 
     if (normalizedType.includes("publication")) {
@@ -144,6 +145,52 @@ function getSearchResultTarget(item: SearchResultItem): string {
     return "/home";
 }
 
+function getApiHostFromBaseUrl(): string {
+    if (apiBaseUrl.length === 0) {
+        return "http://localhost:8080";
+    }
+
+    if (apiBaseUrl.startsWith("http://") || apiBaseUrl.startsWith("https://")) {
+        try {
+            return new URL(apiBaseUrl).origin;
+        } catch {
+            return apiBaseUrl;
+        }
+    }
+
+    return apiBaseUrl;
+}
+
+function resolveSearchResultNavigation(item: SearchResultItem): { externalUrl?: string, internalPath: string } {
+    const rawLink = item.link?.trim();
+    const fallbackPath = getSearchResultFallbackTarget(item);
+
+    if (!rawLink) {
+        return {internalPath: fallbackPath};
+    }
+
+    const normalizedAbsoluteCandidate = rawLink.replace(/^\/+/, "");
+
+    if (/^https?:\/\//i.test(rawLink)) {
+        return {externalUrl: rawLink, internalPath: fallbackPath};
+    }
+
+    if (/^https?:\/\//i.test(normalizedAbsoluteCandidate)) {
+        return {externalUrl: normalizedAbsoluteCandidate, internalPath: fallbackPath};
+    }
+
+    if (rawLink.startsWith("//")) {
+        return {externalUrl: `https:${rawLink}`, internalPath: fallbackPath};
+    }
+
+    const apiHost = getApiHostFromBaseUrl().replace(/\/+$/, "");
+    const normalizedLink = rawLink.replace(/^\/+/, "");
+    return {
+        externalUrl: `${apiHost}/${normalizedLink}`,
+        internalPath: fallbackPath
+    };
+}
+
 export function Navbar() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -155,6 +202,7 @@ export function Navbar() {
     const [searchState, setSearchState] = useState<SearchState>("idle");
     const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
     const [searchError, setSearchError] = useState("");
+    const [externalNavigationUrl, setExternalNavigationUrl] = useState<string | null>(null);
     const menuRef = useRef<HTMLDivElement | null>(null);
     const projectsPanelRef = useRef<HTMLDivElement | null>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
@@ -196,6 +244,7 @@ export function Navbar() {
                 setIsMenuOpen(false);
                 setIsSearchOpen(false);
                 setIsProjectsPanelOpen(false);
+                setExternalNavigationUrl(null);
             }
         };
 
@@ -337,16 +386,19 @@ export function Navbar() {
         return (
             <div className="site-search-results-list">
                 {searchResults.map((item, index) => (
-                    <Link
+                    <button
                         className="site-search-result-card"
                         key={`${item.type}-${item.id}-${item.sourceId ?? index}`}
-                        onClick={() => setIsSearchOpen(false)}
-                        to={getSearchResultTarget(item)}
+                        onClick={() => {
+                            setIsSearchOpen(false);
+                            void openSearchResultInNewTab(item);
+                        }}
+                        type="button"
                     >
                         <span className="site-search-result-type">{getSearchResultTypeLabel(item)}</span>
                         <strong>{getSearchResultTitle(item)}</strong>
                         <span>{getSearchResultDescription(item)}</span>
-                    </Link>
+                    </button>
                 ))}
             </div>
         );
@@ -364,6 +416,115 @@ export function Navbar() {
 
     const closeProjectsPanel = () => {
         setIsProjectsPanelOpen(false);
+    };
+
+    const isApiHostFileUrl = (targetUrl: string): boolean => {
+        try {
+            const parsedTargetUrl = new URL(targetUrl);
+            const parsedApiHostUrl = new URL(getApiHostFromBaseUrl());
+            const isApiHost = parsedTargetUrl.origin === parsedApiHostUrl.origin;
+            const isFilePath = /\/[^/?#]+\.[^/?#]+$/.test(parsedTargetUrl.pathname);
+            return isApiHost && isFilePath;
+        } catch {
+            return false;
+        }
+    };
+
+    const openUpdaterTab = (): Window | null => {
+        const tab = window.open("", "_blank");
+
+        if (!tab) {
+            return null;
+        }
+
+        tab.document.write(`
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Проверка ресурса</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; font-family: "Tilda Sans VF", sans-serif; background: #f7f7f8; color: #181818; }
+    .wrap { display: grid; justify-items: center; gap: 14px; padding: 24px; text-align: center; }
+    .spinner { width: 42px; height: 42px; border: 3px solid #d6d6da; border-top-color: #181818; border-radius: 50%; animation: spin 0.85s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .caption { font-size: 16px; line-height: 1.35; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="spinner" aria-hidden="true"></div>
+    <div class="caption">Проверяем доступность ресурса...</div>
+  </div>
+</body>
+</html>
+        `);
+        tab.document.close();
+        return tab;
+    };
+
+    const openValidatedUrlInNewTab = async (targetUrl: string, openedTab?: Window | null) => {
+        const notFoundUrl = `${window.location.origin}/not-found`;
+        const openUrl = (url: string) => {
+            if (openedTab) {
+                openedTab.location.replace(url);
+                return;
+            }
+
+            window.open(url, "_blank");
+        };
+
+        try {
+            const headResponse = await fetch(targetUrl, {method: "HEAD"});
+
+            if (headResponse.status === 404) {
+                openUrl(notFoundUrl);
+                return;
+            }
+
+            if (headResponse.status === 405) {
+                try {
+                    const getResponse = await fetch(targetUrl, {method: "GET"});
+
+                    if (getResponse.status === 404) {
+                        openUrl(notFoundUrl);
+                        return;
+                    }
+                } catch {
+                    // CORS/opaque response on GET: cannot verify status, allow navigation.
+                }
+            }
+
+            if (!headResponse.ok && headResponse.type !== "opaque" && headResponse.status !== 0) {
+                // For non-404 errors with known status we still allow navigation,
+                // because many resources protect HEAD/GET but are accessible in a browser tab.
+                openUrl(targetUrl);
+                return;
+            }
+
+            openUrl(targetUrl);
+        } catch {
+            // CORS/network restrictions can block status checks from frontend.
+            // In that case, open the resource and let the browser handle it.
+            openUrl(targetUrl);
+        }
+    };
+
+    const openSearchResultInNewTab = async (item: SearchResultItem) => {
+        const navigationTarget = resolveSearchResultNavigation(item);
+
+        if (!navigationTarget.externalUrl) {
+            window.open(`${window.location.origin}${navigationTarget.internalPath}`, "_blank");
+            return;
+        }
+
+        if (!isApiHostFileUrl(navigationTarget.externalUrl)) {
+            setExternalNavigationUrl(navigationTarget.externalUrl);
+            return;
+        }
+
+        await openValidatedUrlInNewTab(navigationTarget.externalUrl);
     };
 
     return (
@@ -744,6 +905,45 @@ export function Navbar() {
                     onClick={closeProjectsPanel}
                     type="button"
                 />
+            )}
+
+            {externalNavigationUrl && (
+                <>
+                    <button
+                        aria-label="Закрыть предупреждение о внешнем ресурсе"
+                        className="site-external-resource-backdrop"
+                        onClick={() => setExternalNavigationUrl(null)}
+                        type="button"
+                    />
+                    <div aria-label="Предупреждение о внешнем ресурсе" className="site-external-resource-modal" role="dialog">
+                        <h3>Вы переходите на внешний ресурс</h3>
+                        <p>Проверьте адрес перед переходом:</p>
+                        <p className="site-external-resource-url">{externalNavigationUrl}</p>
+                        <div className="site-external-resource-actions">
+                            <button
+                                className="site-external-resource-cancel"
+                                onClick={() => setExternalNavigationUrl(null)}
+                                type="button"
+                            >
+                                Отмена
+                            </button>
+                            <button
+                                className="site-external-resource-confirm"
+                                onClick={() => {
+                                    const urlToOpen = externalNavigationUrl;
+                                    setExternalNavigationUrl(null);
+                                    if (urlToOpen) {
+                                        const updaterTab = openUpdaterTab();
+                                        void openValidatedUrlInNewTab(urlToOpen, updaterTab);
+                                    }
+                                }}
+                                type="button"
+                            >
+                                Продолжить
+                            </button>
+                        </div>
+                    </div>
+                </>
             )}
         </header>
     );

--- a/src/view/pages/not-found/NotFoundView.tsx
+++ b/src/view/pages/not-found/NotFoundView.tsx
@@ -1,0 +1,9 @@
+import BodyView from "../BodyView";
+
+export function NotFoundView() {
+    return BodyView(
+        <main style={{padding: "48px 24px", minHeight: "40vh"}}>
+            <h1 style={{margin: 0, fontSize: "32px", lineHeight: 1.2}}>Ничего не найдено</h1>
+        </main>
+    );
+}


### PR DESCRIPTION
## Что сделано
- Добавлена корректная обработка `link` из поиска: абсолютные URL, относительные URL через API host, fallback-маршруты.
- Реализована страница `/not-found` с текстом `Ничего не найдено`.
- Добавлено предупреждение перед переходом на внешний ресурс (кроме файлов на API host).
- После подтверждения открывается новая вкладка с индикатором проверки доступности ресурса.
- При подтверждённом `404` выполняется переход на `/not-found`.
- Если статус внешнего ресурса нельзя надёжно прочитать с фронта (например, CORS), переход не блокируется.

## Проверка
- `npm run build`

Closes #42
