### PR TITLE
feat: unify external navigation policy across all external links

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import {Home} from "./view/pages/home/Home";
 import {ChatView} from "./view/pages/chat/ChatView";
 import {ProjectItemView} from "./view/pages/projects/ProjectItemView";
 import {NotFoundView} from "./view/pages/not-found/NotFoundView";
+import {ExternalFallbackView} from "./view/pages/not-found/ExternalFallbackView";
 import { createBrowserRouter} from "react-router-dom";
 
 const router = createBrowserRouter([
@@ -55,10 +56,7 @@ const router = createBrowserRouter([
     },
     {
         path: "*",
-        Component: () => {
-            window.location.href = "https://www.iae.nsk.su/ru/laboratory-sites/lab-19"
-            return null
-        }
+        element: <ExternalFallbackView/>
     }
 ]);
 

--- a/src/utils/externalNavigation.ts
+++ b/src/utils/externalNavigation.ts
@@ -1,0 +1,118 @@
+const updaterMarkup = `
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Проверка ресурса</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; font-family: "Tilda Sans VF", sans-serif; background: #f7f7f8; color: #181818; }
+    .wrap { display: grid; justify-items: center; gap: 14px; padding: 24px; text-align: center; }
+    .spinner { width: 42px; height: 42px; border: 3px solid #d6d6da; border-top-color: #181818; border-radius: 50%; animation: spin 0.85s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .caption { font-size: 16px; line-height: 1.35; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="spinner" aria-hidden="true"></div>
+    <div class="caption">Проверяем доступность ресурса...</div>
+  </div>
+</body>
+</html>
+`;
+
+interface OpenExternalUrlOptions {
+    notFoundPath?: string
+    openedTab?: Window | null
+}
+
+interface RequestExternalNavigationOptions extends OpenExternalUrlOptions {
+    confirmMessage?: string
+}
+
+function openUpdaterTab(): Window | null {
+    const tab = window.open("", "_blank");
+
+    if (!tab) {
+        return null;
+    }
+
+    tab.document.write(updaterMarkup);
+    tab.document.close();
+    return tab;
+}
+
+function resolveNotFoundUrl(notFoundPath = "/not-found"): string {
+    return `${window.location.origin}${notFoundPath.startsWith("/") ? notFoundPath : `/${notFoundPath}`}`;
+}
+
+function resolveTargetUrl(targetUrl: string): string {
+    return new URL(targetUrl, window.location.origin).toString();
+}
+
+async function isConfirmedNotFound(targetUrl: string): Promise<boolean> {
+    try {
+        const headResponse = await fetch(targetUrl, {method: "HEAD"});
+
+        if (headResponse.status === 404) {
+            return true;
+        }
+
+        if (headResponse.status === 405) {
+            try {
+                const getResponse = await fetch(targetUrl, {method: "GET"});
+                return getResponse.status === 404;
+            } catch {
+                // Some resources block CORS checks, fallback to open resource in browser tab.
+                return false;
+            }
+        }
+
+        return false;
+    } catch {
+        // Cannot reliably check status (network/CORS), do not block navigation.
+        return false;
+    }
+}
+
+function openUrlInTab(url: string, openedTab?: Window | null) {
+    if (openedTab) {
+        openedTab.location.replace(url);
+        return;
+    }
+
+    window.open(url, "_blank");
+}
+
+export function isExternalResourceUrl(targetUrl: string): boolean {
+    try {
+        return new URL(targetUrl, window.location.origin).origin !== window.location.origin;
+    } catch {
+        return false;
+    }
+}
+
+export async function openExternalUrlInNewTabWithCheck(targetUrl: string, options: OpenExternalUrlOptions = {}): Promise<void> {
+    const resolvedTarget = resolveTargetUrl(targetUrl);
+    const openedTab = options.openedTab ?? openUpdaterTab();
+    const notFoundUrl = resolveNotFoundUrl(options.notFoundPath);
+
+    if (!openedTab) {
+        return;
+    }
+
+    const notFound = await isConfirmedNotFound(resolvedTarget);
+    openUrlInTab(notFound ? notFoundUrl : resolvedTarget, openedTab);
+}
+
+export async function requestExternalNavigation(targetUrl: string, options: RequestExternalNavigationOptions = {}): Promise<void> {
+    const resolvedTarget = resolveTargetUrl(targetUrl);
+    const confirmed = window.confirm(options.confirmMessage ?? `Вы переходите на внешний ресурс:\n${resolvedTarget}\n\nПродолжить?`);
+
+    if (!confirmed) {
+        return;
+    }
+
+    await openExternalUrlInNewTabWithCheck(resolvedTarget, options);
+}

--- a/src/utils/externalNavigation.ts
+++ b/src/utils/externalNavigation.ts
@@ -27,9 +27,12 @@ interface OpenExternalUrlOptions {
     openedTab?: Window | null
 }
 
-interface RequestExternalNavigationOptions extends OpenExternalUrlOptions {
-    confirmMessage?: string
+export interface ExternalNavigationRequestDetail {
+    targetUrl: string
+    notFoundPath?: string
 }
+
+export const EXTERNAL_NAVIGATION_REQUEST_EVENT = "site-external-navigation:request";
 
 function openUpdaterTab(): Window | null {
     const tab = window.open("", "_blank");
@@ -106,13 +109,13 @@ export async function openExternalUrlInNewTabWithCheck(targetUrl: string, option
     openUrlInTab(notFound ? notFoundUrl : resolvedTarget, openedTab);
 }
 
-export async function requestExternalNavigation(targetUrl: string, options: RequestExternalNavigationOptions = {}): Promise<void> {
+export async function requestExternalNavigation(targetUrl: string, options: OpenExternalUrlOptions = {}): Promise<void> {
     const resolvedTarget = resolveTargetUrl(targetUrl);
-    const confirmed = window.confirm(options.confirmMessage ?? `Вы переходите на внешний ресурс:\n${resolvedTarget}\n\nПродолжить?`);
-
-    if (!confirmed) {
-        return;
-    }
-
-    await openExternalUrlInNewTabWithCheck(resolvedTarget, options);
+    const event = new CustomEvent<ExternalNavigationRequestDetail>(EXTERNAL_NAVIGATION_REQUEST_EVENT, {
+        detail: {
+            targetUrl: resolvedTarget,
+            notFoundPath: options.notFoundPath
+        }
+    });
+    window.dispatchEvent(event);
 }

--- a/src/view/common/footer/Footer.tsx
+++ b/src/view/common/footer/Footer.tsx
@@ -1,9 +1,11 @@
 import {useCallback} from "react";
+import type {MouseEvent as ReactMouseEvent} from "react";
 import {Link} from "react-router-dom";
 import {ProjectsFooterRow} from "../../../data/footer/ProjectsFooterRow";
 import {getGroupedPublications, getGroupedStudentWorks} from "../../../api/knowledgeBaseApi";
 import {useRemoteData} from "../../../hooks/useRemoteData";
 import type {FooterRawDataElement} from "../../../model/footer/FooterRawDataElement";
+import {requestExternalNavigation} from "../../../utils/externalNavigation";
 import searchIcon from "../../../assets/home/icons/search.svg";
 import arrowTopIcon from "../../../assets/home/icons/arrow-top.svg";
 
@@ -32,6 +34,11 @@ export function Footer() {
         window.dispatchEvent(new CustomEvent("site-search:open"));
     };
 
+    const handleExternalLinkClick = (url: string) => (event: ReactMouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+        void requestExternalNavigation(url);
+    };
+
     return (
         <footer className="site-footer">
             <div className="site-footer-top">
@@ -51,9 +58,9 @@ export function Footer() {
                 <div className="site-footer-meta" id="contacts">
                     <p>Почта: poprog.industrial@gmail.com</p>
                     <div className="site-footer-socials">
-                        <a href="https://t.me/poprog" rel="noopener noreferrer" target="_blank">Телеграмм</a>
-                        <a href="https://reddit.com/r/poprog/" rel="noopener noreferrer" target="_blank">Реддит</a>
-                        <a href="https://github.com/egorkuzn/poprog-knowledge-base-front" rel="noopener noreferrer" target="_blank">Гитхаб</a>
+                        <a href="https://t.me/poprog" onClick={handleExternalLinkClick("https://t.me/poprog")} rel="noopener noreferrer" target="_blank">Телеграмм</a>
+                        <a href="https://reddit.com/r/poprog/" onClick={handleExternalLinkClick("https://reddit.com/r/poprog/")} rel="noopener noreferrer" target="_blank">Реддит</a>
+                        <a href="https://github.com/egorkuzn/poprog-knowledge-base-front" onClick={handleExternalLinkClick("https://github.com/egorkuzn/poprog-knowledge-base-front")} rel="noopener noreferrer" target="_blank">Гитхаб</a>
                     </div>
                     <a href="#about">О нас</a>
                     <a href="#support">Помочь проекту</a>

--- a/src/view/common/footer/FooterContactsRowView.tsx
+++ b/src/view/common/footer/FooterContactsRowView.tsx
@@ -1,4 +1,5 @@
 import {Component} from "react";
+import {requestExternalNavigation} from "../../../utils/externalNavigation";
 
 export class FooterContactsRowView extends Component<any> {
     render() {
@@ -28,7 +29,21 @@ class ContactElementView extends Component<ContactElementProp> {
         if (this.props.path === "") {
             return <li>{phrase}</li>
         } else {
-            return <li><a href={this.props.path} target="_blank" rel="noopener noreferrer">{phrase}</a></li>;
+            return (
+                <li>
+                    <a
+                        href={this.props.path}
+                        onClick={(event) => {
+                            event.preventDefault();
+                            void requestExternalNavigation(this.props.path);
+                        }}
+                        rel="noopener noreferrer"
+                        target="_blank"
+                    >
+                        {phrase}
+                    </a>
+                </li>
+            );
         }
     }
 }

--- a/src/view/common/navbar/Navbar.tsx
+++ b/src/view/common/navbar/Navbar.tsx
@@ -3,6 +3,7 @@ import {Link, NavLink, useLocation} from "react-router-dom";
 import {searchKnowledgeBase} from "../../../api/knowledgeBaseApi";
 import {apiBaseUrl} from "../../../api/config";
 import type {SearchResultItem} from "../../../api/types";
+import {openExternalUrlInNewTabWithCheck} from "../../../utils/externalNavigation";
 import {NavigationTree} from "../../../data/navbar/NavigationTree";
 import searchIcon from "../../../assets/home/icons/search.svg";
 import accountIcon from "../../../assets/home/icons/account.svg";
@@ -418,99 +419,6 @@ export function Navbar() {
         setIsProjectsPanelOpen(false);
     };
 
-    const isApiHostFileUrl = (targetUrl: string): boolean => {
-        try {
-            const parsedTargetUrl = new URL(targetUrl);
-            const parsedApiHostUrl = new URL(getApiHostFromBaseUrl());
-            const isApiHost = parsedTargetUrl.origin === parsedApiHostUrl.origin;
-            const isFilePath = /\/[^/?#]+\.[^/?#]+$/.test(parsedTargetUrl.pathname);
-            return isApiHost && isFilePath;
-        } catch {
-            return false;
-        }
-    };
-
-    const openUpdaterTab = (): Window | null => {
-        const tab = window.open("", "_blank");
-
-        if (!tab) {
-            return null;
-        }
-
-        tab.document.write(`
-<!doctype html>
-<html lang="ru">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Проверка ресурса</title>
-  <style>
-    body { margin: 0; min-height: 100vh; display: grid; place-items: center; font-family: "Tilda Sans VF", sans-serif; background: #f7f7f8; color: #181818; }
-    .wrap { display: grid; justify-items: center; gap: 14px; padding: 24px; text-align: center; }
-    .spinner { width: 42px; height: 42px; border: 3px solid #d6d6da; border-top-color: #181818; border-radius: 50%; animation: spin 0.85s linear infinite; }
-    @keyframes spin { to { transform: rotate(360deg); } }
-    .caption { font-size: 16px; line-height: 1.35; }
-  </style>
-</head>
-<body>
-  <div class="wrap">
-    <div class="spinner" aria-hidden="true"></div>
-    <div class="caption">Проверяем доступность ресурса...</div>
-  </div>
-</body>
-</html>
-        `);
-        tab.document.close();
-        return tab;
-    };
-
-    const openValidatedUrlInNewTab = async (targetUrl: string, openedTab?: Window | null) => {
-        const notFoundUrl = `${window.location.origin}/not-found`;
-        const openUrl = (url: string) => {
-            if (openedTab) {
-                openedTab.location.replace(url);
-                return;
-            }
-
-            window.open(url, "_blank");
-        };
-
-        try {
-            const headResponse = await fetch(targetUrl, {method: "HEAD"});
-
-            if (headResponse.status === 404) {
-                openUrl(notFoundUrl);
-                return;
-            }
-
-            if (headResponse.status === 405) {
-                try {
-                    const getResponse = await fetch(targetUrl, {method: "GET"});
-
-                    if (getResponse.status === 404) {
-                        openUrl(notFoundUrl);
-                        return;
-                    }
-                } catch {
-                    // CORS/opaque response on GET: cannot verify status, allow navigation.
-                }
-            }
-
-            if (!headResponse.ok && headResponse.type !== "opaque" && headResponse.status !== 0) {
-                // For non-404 errors with known status we still allow navigation,
-                // because many resources protect HEAD/GET but are accessible in a browser tab.
-                openUrl(targetUrl);
-                return;
-            }
-
-            openUrl(targetUrl);
-        } catch {
-            // CORS/network restrictions can block status checks from frontend.
-            // In that case, open the resource and let the browser handle it.
-            openUrl(targetUrl);
-        }
-    };
-
     const openSearchResultInNewTab = async (item: SearchResultItem) => {
         const navigationTarget = resolveSearchResultNavigation(item);
 
@@ -518,13 +426,7 @@ export function Navbar() {
             window.open(`${window.location.origin}${navigationTarget.internalPath}`, "_blank");
             return;
         }
-
-        if (!isApiHostFileUrl(navigationTarget.externalUrl)) {
-            setExternalNavigationUrl(navigationTarget.externalUrl);
-            return;
-        }
-
-        await openValidatedUrlInNewTab(navigationTarget.externalUrl);
+        setExternalNavigationUrl(navigationTarget.externalUrl);
     };
 
     return (
@@ -933,8 +835,7 @@ export function Navbar() {
                                     const urlToOpen = externalNavigationUrl;
                                     setExternalNavigationUrl(null);
                                     if (urlToOpen) {
-                                        const updaterTab = openUpdaterTab();
-                                        void openValidatedUrlInNewTab(urlToOpen, updaterTab);
+                                        void openExternalUrlInNewTabWithCheck(urlToOpen);
                                     }
                                 }}
                                 type="button"

--- a/src/view/common/navbar/Navbar.tsx
+++ b/src/view/common/navbar/Navbar.tsx
@@ -3,7 +3,11 @@ import {Link, NavLink, useLocation} from "react-router-dom";
 import {searchKnowledgeBase} from "../../../api/knowledgeBaseApi";
 import {apiBaseUrl} from "../../../api/config";
 import type {SearchResultItem} from "../../../api/types";
-import {openExternalUrlInNewTabWithCheck} from "../../../utils/externalNavigation";
+import {
+    EXTERNAL_NAVIGATION_REQUEST_EVENT,
+    openExternalUrlInNewTabWithCheck,
+    type ExternalNavigationRequestDetail
+} from "../../../utils/externalNavigation";
 import {NavigationTree} from "../../../data/navbar/NavigationTree";
 import searchIcon from "../../../assets/home/icons/search.svg";
 import accountIcon from "../../../assets/home/icons/account.svg";
@@ -203,7 +207,7 @@ export function Navbar() {
     const [searchState, setSearchState] = useState<SearchState>("idle");
     const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
     const [searchError, setSearchError] = useState("");
-    const [externalNavigationUrl, setExternalNavigationUrl] = useState<string | null>(null);
+    const [externalNavigationRequest, setExternalNavigationRequest] = useState<ExternalNavigationRequestDetail | null>(null);
     const menuRef = useRef<HTMLDivElement | null>(null);
     const projectsPanelRef = useRef<HTMLDivElement | null>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
@@ -245,7 +249,7 @@ export function Navbar() {
                 setIsMenuOpen(false);
                 setIsSearchOpen(false);
                 setIsProjectsPanelOpen(false);
-                setExternalNavigationUrl(null);
+                setExternalNavigationRequest(null);
             }
         };
 
@@ -255,14 +259,33 @@ export function Navbar() {
             setIsSearchOpen(true);
         };
 
+        const handleExternalNavigationRequest = (event: Event) => {
+            const customEvent = event as CustomEvent<ExternalNavigationRequestDetail>;
+            const targetUrl = customEvent.detail?.targetUrl;
+
+            if (!targetUrl) {
+                return;
+            }
+
+            setIsMenuOpen(false);
+            setIsSearchOpen(false);
+            setIsProjectsPanelOpen(false);
+            setExternalNavigationRequest({
+                targetUrl,
+                notFoundPath: customEvent.detail?.notFoundPath
+            });
+        };
+
         document.addEventListener("mousedown", handleOutsideClick);
         document.addEventListener("keydown", handleEscape);
         window.addEventListener("site-search:open", handleOpenSearch);
+        window.addEventListener(EXTERNAL_NAVIGATION_REQUEST_EVENT, handleExternalNavigationRequest as EventListener);
 
         return () => {
             document.removeEventListener("mousedown", handleOutsideClick);
             document.removeEventListener("keydown", handleEscape);
             window.removeEventListener("site-search:open", handleOpenSearch);
+            window.removeEventListener(EXTERNAL_NAVIGATION_REQUEST_EVENT, handleExternalNavigationRequest as EventListener);
         };
     }, [isMenuOpen]);
 
@@ -426,7 +449,9 @@ export function Navbar() {
             window.open(`${window.location.origin}${navigationTarget.internalPath}`, "_blank");
             return;
         }
-        setExternalNavigationUrl(navigationTarget.externalUrl);
+        setExternalNavigationRequest({
+            targetUrl: navigationTarget.externalUrl
+        });
     };
 
     return (
@@ -809,22 +834,22 @@ export function Navbar() {
                 />
             )}
 
-            {externalNavigationUrl && (
+            {externalNavigationRequest && (
                 <>
                     <button
                         aria-label="Закрыть предупреждение о внешнем ресурсе"
                         className="site-external-resource-backdrop"
-                        onClick={() => setExternalNavigationUrl(null)}
+                        onClick={() => setExternalNavigationRequest(null)}
                         type="button"
                     />
                     <div aria-label="Предупреждение о внешнем ресурсе" className="site-external-resource-modal" role="dialog">
                         <h3>Вы переходите на внешний ресурс</h3>
                         <p>Проверьте адрес перед переходом:</p>
-                        <p className="site-external-resource-url">{externalNavigationUrl}</p>
+                        <p className="site-external-resource-url">{externalNavigationRequest.targetUrl}</p>
                         <div className="site-external-resource-actions">
                             <button
                                 className="site-external-resource-cancel"
-                                onClick={() => setExternalNavigationUrl(null)}
+                                onClick={() => setExternalNavigationRequest(null)}
                                 type="button"
                             >
                                 Отмена
@@ -832,10 +857,12 @@ export function Navbar() {
                             <button
                                 className="site-external-resource-confirm"
                                 onClick={() => {
-                                    const urlToOpen = externalNavigationUrl;
-                                    setExternalNavigationUrl(null);
-                                    if (urlToOpen) {
-                                        void openExternalUrlInNewTabWithCheck(urlToOpen);
+                                    const requestToOpen = externalNavigationRequest;
+                                    setExternalNavigationRequest(null);
+                                    if (requestToOpen) {
+                                        void openExternalUrlInNewTabWithCheck(requestToOpen.targetUrl, {
+                                            notFoundPath: requestToOpen.notFoundPath
+                                        });
                                     }
                                 }}
                                 type="button"

--- a/src/view/pages/not-found/ExternalFallbackView.tsx
+++ b/src/view/pages/not-found/ExternalFallbackView.tsx
@@ -1,0 +1,33 @@
+import BodyView from "../BodyView";
+import {requestExternalNavigation} from "../../../utils/externalNavigation";
+
+const fallbackExternalUrl = "https://www.iae.nsk.su/ru/laboratory-sites/lab-19";
+
+export function ExternalFallbackView() {
+    return BodyView(
+        <main style={{padding: "48px 24px", minHeight: "40vh"}}>
+            <h1 style={{margin: 0, fontSize: "32px", lineHeight: 1.2}}>Страница не найдена</h1>
+            <p style={{marginTop: "16px", maxWidth: "760px"}}>
+                Вы можете перейти на внешний сайт лаборатории, чтобы продолжить поиск информации.
+            </p>
+            <button
+                onClick={() => {
+                    void requestExternalNavigation(fallbackExternalUrl);
+                }}
+                style={{
+                    marginTop: "20px",
+                    minHeight: "44px",
+                    padding: "0 18px",
+                    borderRadius: "12px",
+                    border: "1px solid #171717",
+                    background: "#171717",
+                    color: "#ffffff",
+                    cursor: "pointer"
+                }}
+                type="button"
+            >
+                Перейти на сайт лаборатории
+            </button>
+        </main>
+    );
+}

--- a/src/view/pages/publications/PublicationsView.tsx
+++ b/src/view/pages/publications/PublicationsView.tsx
@@ -1,27 +1,43 @@
 import {useCallback} from "react";
-import type {JSX} from "react";
+import type {JSX, MouseEvent as ReactMouseEvent} from "react";
 import BodyView from "../BodyView";
 import "../../../styles/pages/Publications.scss";
 import {getGroupedPublications} from "../../../api/knowledgeBaseApi";
 import type {PublicationModel, PublicationsByDateDto} from "../../../api/types";
 import {useRemoteData} from "../../../hooks/useRemoteData";
+import {isExternalResourceUrl, requestExternalNavigation} from "../../../utils/externalNavigation";
 
 export function PublicationsView() {
     const loadPublications = useCallback(() => getGroupedPublications(), []);
     const {data, error, isLoading} = useRemoteData(loadPublications);
+    const handlePublicationLinkClick = (publicationLink: string) => (event: ReactMouseEvent<HTMLAnchorElement>) => {
+        if (!isExternalResourceUrl(publicationLink)) {
+            return;
+        }
 
-    return BodyView(page(data, isLoading, error));
+        event.preventDefault();
+        void requestExternalNavigation(publicationLink);
+    };
+
+    return BodyView(page(data, isLoading, error, handlePublicationLinkClick));
 }
 
-function renderPublicationLink(publication: PublicationModel, element: JSX.Element) {
+type PublicationLinkClickHandler = (publicationLink: string) => (event: ReactMouseEvent<HTMLAnchorElement>) => void;
+
+function renderPublicationLink(publication: PublicationModel, element: JSX.Element, onPublicationLinkClick: PublicationLinkClickHandler) {
     return publication.link === "" ? element : (
-        <a href={publication.link} target="_blank" rel="noopener noreferrer">
+        <a href={publication.link} onClick={onPublicationLinkClick(publication.link)} rel="noopener noreferrer" target="_blank">
             {element}
         </a>
     );
 }
 
-function page(publications: PublicationsByDateDto[] | null, isLoading: boolean, error: string | null) {
+function page(
+    publications: PublicationsByDateDto[] | null,
+    isLoading: boolean,
+    error: string | null,
+    onPublicationLinkClick: PublicationLinkClickHandler
+) {
     return (
         <main>
             <div className="publications-page">
@@ -37,12 +53,13 @@ function page(publications: PublicationsByDateDto[] | null, isLoading: boolean, 
                         {publicationsByDate.publications.map((publication, index) => (
                             <div className="publication" key={`${publicationsByDate.date}-${index}-${publication.theme}`}>
                                 <div className="publication-authors-titles">
-                                    {renderPublicationLink(publication, <p>{publication.authors}</p>)}
-                                    {renderPublicationLink(publication, <p>{publication.theme}</p>)}
+                                    {renderPublicationLink(publication, <p>{publication.authors}</p>, onPublicationLinkClick)}
+                                    {renderPublicationLink(publication, <p>{publication.theme}</p>, onPublicationLinkClick)}
                                 </div>
                                 {renderPublicationLink(
                                     publication,
-                                    <p className="publication-published">{publication.published}</p>
+                                    <p className="publication-published">{publication.published}</p>,
+                                    onPublicationLinkClick
                                 )}
                             </div>
                         ))}


### PR DESCRIPTION
## Что сделано
- Вынесен общий механизм внешних переходов в `src/utils/externalNavigation.ts`.
- Реализован единый поток: согласие пользователя -> новая вкладка -> updater -> проверка доступности -> переход / `/not-found` при подтвержденном `404`.
- Актуализирован сценарий из #42 в `Navbar`: поиск использует общий механизм проверки перехода на внешний ресурс.
- Обновлены точки внешних переходов:
  - `src/view/pages/publications/PublicationsView.tsx`
  - `src/view/common/footer/Footer.tsx`
  - `src/view/common/footer/FooterContactsRowView.tsx`
  - wildcard-роут в `src/main.tsx` (через новую страницу `ExternalFallbackView`)
- Добавлен `src/view/pages/not-found/ExternalFallbackView.tsx` для безопасного перехода на внешний сайт по согласию пользователя.

## Проверка
- `npm run build`

Closes #47
