### PR TITLE
ci: add per-service frontend deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+node_modules
+dist
+coverage
+.env
+.env.*
+*.local
+*.log
+.DS_Store
+.idea
+.vscode
+*.iml
+package-lock 2.json

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,20 +1,26 @@
-name: Frontend CI
+name: Frontend CI/CD
 
 on:
   push:
     branches:
       - main
-      - master
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/poprog-knowledge-base-front
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: .
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,8 +35,97 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Test
+      - name: Typecheck
         run: npm run test
 
       - name: Build
-        run: npm run build
+        run: npm run build -- --base=/portal/
+        env:
+          VITE_API_BASE_URL: /portal-api
+          VITE_DEBUG_HEADERS_ENABLED: "false"
+          VITE_RIDE_CONSOLE_URL: /admin/master/console/
+          VITE_RIDE_SIGNUP_URL: /account
+
+  docker-deploy:
+    needs: build-test
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+          build-args: |
+            VITE_API_BASE_URL=/portal-api
+            VITE_DEBUG_HEADERS_ENABLED=false
+            VITE_RIDE_CONSOLE_URL=/admin/master/console/
+            VITE_RIDE_SIGNUP_URL=/account
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy frontend only
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          IMAGE: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "IMAGE='$IMAGE' GHCR_USER='$GHCR_USER' GHCR_TOKEN='$GHCR_TOKEN' bash -s" <<'REMOTE'
+          set -euo pipefail
+          mkdir -p ~/frontend
+          cd ~/frontend
+          cat > docker-compose.yml <<EOF2
+          services:
+            portal-frontend:
+              image: ${IMAGE}
+              container_name: poprog-portal-frontend
+              restart: unless-stopped
+              ports:
+                - "127.0.0.1:18083:80"
+          EOF2
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null
+          docker compose pull portal-frontend
+          docker compose up -d portal-frontend
+          docker logout ghcr.io >/dev/null
+          REMOTE
+
+      - name: Apply nginx routing
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          scp -i ~/.ssh/deploy_key deploy/poprog-edge-nginx.conf "$DEPLOY_USER@$DEPLOY_HOST:/tmp/poprog-edge-nginx.conf"
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" <<'REMOTE'
+          set -euo pipefail
+          sudo cp /etc/nginx/sites-available/auth-ride /etc/nginx/sites-available/auth-ride.$(date +%Y%m%d%H%M%S)
+          sudo tee /etc/nginx/sites-available/auth-ride >/dev/null < /tmp/poprog-edge-nginx.conf
+          sudo nginx -t
+          sudo systemctl reload nginx
+          REMOTE
+
+      - name: Smoke check frontend
+        run: |
+          curl -fsSIL "http://${{ secrets.DEPLOY_HOST }}/portal/"
+          curl -fsSI "http://${{ secrets.DEPLOY_HOST }}/portal/assets/" || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+ARG VITE_API_BASE_URL=/portal-api
+ARG VITE_DEBUG_HEADERS_ENABLED=false
+ARG VITE_RIDE_CONSOLE_URL=/admin/master/console/
+ARG VITE_RIDE_SIGNUP_URL=/account
+
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_DEBUG_HEADERS_ENABLED=$VITE_DEBUG_HEADERS_ENABLED
+ENV VITE_RIDE_CONSOLE_URL=$VITE_RIDE_CONSOLE_URL
+ENV VITE_RIDE_SIGNUP_URL=$VITE_RIDE_SIGNUP_URL
+
+RUN npm run build -- --base=/portal/
+
+FROM nginx:1.27-alpine
+
+COPY deploy/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist/ /usr/share/nginx/html/

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /portal {
+        return 301 /portal/;
+    }
+
+    location /portal/ {
+        alias /usr/share/nginx/html/;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/deploy/poprog-edge-nginx.conf
+++ b/deploy/poprog-edge-nginx.conf
@@ -1,0 +1,97 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    client_max_body_size 25m;
+
+    location /auth-api/ {
+        proxy_pass http://127.0.0.1:8081/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /portal-api/ {
+        proxy_pass http://127.0.0.1:18082/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:18082/api/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /actuator/ {
+        proxy_pass http://127.0.0.1:18082/actuator/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /files/ {
+        proxy_pass http://127.0.0.1:18082/files/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /swagger-ui/ {
+        proxy_pass http://127.0.0.1:18082/swagger-ui/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /v3/ {
+        proxy_pass http://127.0.0.1:18082/v3/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location ~ ^/(admin|realms|resources)/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port $server_port;
+    }
+
+    location /portal/ {
+        proxy_pass http://127.0.0.1:18083/portal/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location = /portal {
+        return 301 /portal/;
+    }
+
+    location = / {
+        return 302 /portal/;
+    }
+}


### PR DESCRIPTION
Closes #87\n\n## Summary\n- add frontend GitHub Actions build/test and GHCR publish\n- deploy only the frontend container to poprog-edge over SSH\n- add nginx routing template for /portal and backend/auth proxies\n- add Dockerfile and .dockerignore to keep local secrets and build artifacts out of image context\n\n## Verification\n- npm ci\n- npm run test\n- npm run build -- --base=/portal/\n- secret scan for private keys and known server passwords