### PR TITLE
fix(front): ensure postinstall script exists during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./
+COPY scripts/fix-bufbuild-protobuf-cjs.cjs ./scripts/
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
## Fix summary
- In Dockerfile,  runs  and needs  to be present in build context before install.
- Added explicit copy of this script before  during Docker build.

## Why it failed
Deployment job in  was failing during  at :
.

## Validation
- Local  passes and completes image build successfully.
- CI build/test stage is unchanged.
