### PR TITLE
fix(front-ci): cleanup stale frontend container before deploy

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -107,6 +107,7 @@ jobs:
           EOF2
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null
           docker compose pull portal-frontend
+          docker rm -f poprog-portal-frontend >/dev/null 2>&1 || true
           docker compose up -d portal-frontend
           docker logout ghcr.io >/dev/null
           REMOTE


### PR DESCRIPTION
Fix frontend deploy to remove stale poprog-portal-frontend container before docker compose up, prevents deploy failures in repeated runs.