### PR TITLE
feat: improve publications and works readability + GOST copy UX

### DIFF
--- a/src/styles/pages/Publications.scss
+++ b/src/styles/pages/Publications.scss
@@ -1,12 +1,41 @@
 
 .publications-page {
-  padding-left: 2em;
-  padding-right: 2em;
+  padding: 10px 20px 42px;
+  min-height: 62vh;
+  background: #f4f6fb;
 }
 
-.publications-page h1,
-.publications-page h2 {
-  color: inherit;
+.publications-hero {
+  max-width: 1100px;
+  margin: 0 auto 14px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: linear-gradient(120deg, #1f3066 0%, #385bba 100%);
+  color: #fff;
+}
+
+.publications-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3.4vw, 2.7rem);
+}
+
+.publications-hero p {
+  margin: 8px 0 0;
+  max-width: 78ch;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.publications-year-block {
+  max-width: 1100px;
+  margin: 0 auto 12px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid #dbe2f1;
+  background: #fff;
+}
+
+.publications-year-block h2 {
+  margin: 0 0 8px;
 }
 
 .publications-page a {
@@ -16,8 +45,21 @@
 
 .publication {
   display: grid;
-  row-gap: 0;
+  row-gap: 0.2em;
+  padding: 10px 0;
+  border-top: 1px solid #e8edf7;
   scroll-margin-top: 96px;
+}
+
+.publication:first-of-type {
+  border-top: 0;
+}
+
+.publication-primary-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75em;
 }
 
 .publication.search-focus-highlight {
@@ -26,14 +68,39 @@
 }
 
 .publication-authors-titles {
-  display: flex;
-  flex-direction: column;
-  row-gap: 0.15em;
   width: 100%;
 }
 
+.publication-authors-titles p {
+  margin: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+}
+
+.publication-copy-button {
+  border: 1px solid transparent;
+  background: transparent;
+  color: #1f232b;
+  border-radius: 0.5rem;
+  min-width: 2.75rem;
+  height: 2rem;
+  padding: 0 0.55rem;
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 600;
+  line-height: 1;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.publication-copy-button:hover {
+  color: #f3f5f8;
+  background: #2a303a;
+  border-color: #404857;
+}
+
 .publication-published {
-  font-weight: lighter;
+  color: #5b667d;
   margin-top: 0.35em;
   white-space: normal;
   overflow-wrap: anywhere;
@@ -41,9 +108,43 @@
 }
 
 .remote-data-state {
+  max-width: 1100px;
+  margin: 8px auto;
   color: #444444;
 }
 
 .remote-data-state-error {
   color: #8a1c1c;
+}
+
+.publication-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1.25rem;
+  transform: translateX(-50%);
+  background: #1f232b;
+  color: #f8f9fb;
+  border: 1px solid #353b46;
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  z-index: 2200;
+  pointer-events: none;
+}
+
+@media (max-width: 720px) {
+  .publications-page {
+    padding: 8px 10px 28px;
+  }
+
+  .publications-hero {
+    border-radius: 16px;
+    padding: 16px;
+  }
+
+  .publications-year-block {
+    padding: 12px;
+  }
 }

--- a/src/styles/pages/Works.scss
+++ b/src/styles/pages/Works.scss
@@ -1,17 +1,52 @@
-
 .works-page {
-  padding-left: 2em;
-  padding-right: 2em;
+  padding: 10px 20px 42px;
+  min-height: 62vh;
+  background: #f4f6fb;
+}
+
+.works-hero {
+  max-width: 1100px;
+  margin: 0 auto 14px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: linear-gradient(120deg, #1f3066 0%, #385bba 100%);
+  color: #fff;
+}
+
+.works-hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 3.4vw, 2.7rem);
+}
+
+.works-hero p {
+  margin: 8px 0 0;
+  max-width: 78ch;
+  color: rgba(255, 255, 255, 0.92);
 }
 
 .works-class {
+  max-width: 1100px;
+  margin: 0 auto 12px;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid #dbe2f1;
+  background: #fff;
+}
 
+.works-class h2 {
+  margin: 0 0 8px;
 }
 
 .work {
   display: grid;
-  row-gap: 0;
+  row-gap: 0.2em;
+  padding: 10px 0;
+  border-top: 1px solid #e8edf7;
   scroll-margin-top: 96px;
+}
+
+.work:first-of-type {
+  border-top: 0;
 }
 
 .work.search-focus-highlight {
@@ -19,24 +54,44 @@
   transition: background-color 0.35s ease;
 }
 
-.work-authors-titles {
-  display: flex;
-  column-gap: 0.25em;
-}
-
 .work-published {
-  font-weight: lighter;
+  color: #5b667d;
   margin-top: 0;
+  line-height: 1.35;
 }
 
-.works-page h1, h2 {
-  color: black;
+.work-authors-titles {
+  color: #111827;
+}
+
+.work-authors-titles p {
+  margin: 0;
+  line-height: 1.4;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .remote-data-state {
+  max-width: 1100px;
+  margin: 8px auto;
   color: #444444;
 }
 
 .remote-data-state-error {
   color: #8a1c1c;
+}
+
+@media (max-width: 720px) {
+  .works-page {
+    padding: 8px 10px 28px;
+  }
+
+  .works-hero {
+    border-radius: 16px;
+    padding: 16px;
+  }
+
+  .works-class {
+    padding: 12px;
+  }
 }

--- a/src/view/pages/publications/PublicationsView.tsx
+++ b/src/view/pages/publications/PublicationsView.tsx
@@ -15,6 +15,7 @@ export function PublicationsView() {
     const loadPublications = useCallback(() => getGroupedPublications(), []);
     const {data, error, isLoading} = useRemoteData(loadPublications);
     const [doiChoice, setDoiChoice] = useState<null | {pdfUrl: string, doiUrl: string}>(null);
+    const [toastMessage, setToastMessage] = useState<string | null>(null);
 
     const handlePublicationLinkClick = (publication: PublicationModel) => (event: ReactMouseEvent<HTMLAnchorElement>) => {
         const normalized = resolvePublicationLink(publication.link);
@@ -61,7 +62,42 @@ export function PublicationsView() {
         return () => window.clearTimeout(timeoutId);
     }, [searchParams, isLoading, error, data]);
 
-    return BodyView(page(data, isLoading, error, handlePublicationLinkClick, doiChoice, setDoiChoice));
+    const copyPublicationGost = useCallback(async (publication: PublicationModel) => {
+        const gostText = formatPublicationGost(publication);
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(gostText);
+            } else {
+                const textarea = document.createElement("textarea");
+                textarea.value = gostText;
+                textarea.setAttribute("readonly", "true");
+                textarea.style.position = "absolute";
+                textarea.style.left = "-9999px";
+                document.body.appendChild(textarea);
+                textarea.select();
+                const copied = document.execCommand("copy");
+                document.body.removeChild(textarea);
+                if (!copied) {
+                    throw new Error("copy-failed");
+                }
+            }
+            setToastMessage("Скопировано!");
+            window.setTimeout(() => setToastMessage(null), 1800);
+        } catch {
+            window.alert("Не удалось скопировать автоматически. Разрешите доступ к буферу обмена в браузере.");
+        }
+    }, []);
+
+    return BodyView(page(
+        data,
+        isLoading,
+        error,
+        handlePublicationLinkClick,
+        doiChoice,
+        setDoiChoice,
+        copyPublicationGost,
+        toastMessage
+    ));
 }
 
 type PublicationLinkClickHandler = (publication: PublicationModel) => (event: ReactMouseEvent<HTMLAnchorElement>) => void;
@@ -93,20 +129,25 @@ function page(
     error: string | null,
     onPublicationLinkClick: PublicationLinkClickHandler,
     doiChoice: null | {pdfUrl: string, doiUrl: string},
-    setDoiChoice: (value: null | {pdfUrl: string, doiUrl: string}) => void
+    setDoiChoice: (value: null | {pdfUrl: string, doiUrl: string}) => void,
+    onCopyPublicationGost: (publication: PublicationModel) => void,
+    toastMessage: string | null
 ) {
     return (
         <main>
             <Breadcrumbs items={[{label: "Главная", to: "/home"}, {label: "Публикации"}]}/>
             <div className="publications-page">
-                <h1>Публикации</h1>
+                <section className="publications-hero">
+                    <h1>Публикации</h1>
+                    <p>Научные статьи и материалы по процесс-ориентированному программированию для обучения и исследований.</p>
+                </section>
                 {isLoading && <p className="remote-data-state">Загрузка публикаций...</p>}
                 {error && <p className="remote-data-state remote-data-state-error">Не удалось загрузить публикации: {error}</p>}
                 {!isLoading && !error && publications?.length === 0 && (
                     <p className="remote-data-state">Публикации пока не найдены.</p>
                 )}
                 {publications?.map((publicationsByDate) => (
-                    <div className="section-spacer" id={publicationsByDate.date} key={publicationsByDate.date}>
+                    <section className="publications-year-block section-spacer" id={publicationsByDate.date} key={publicationsByDate.date}>
                         <h2>{publicationsByDate.date}</h2>
                         {publicationsByDate.publications.map((publication, index) => (
                             <div
@@ -114,9 +155,25 @@ function page(
                                 id={`publication-${publication.id}`}
                                 key={`${publicationsByDate.date}-${publication.id}-${index}`}
                             >
-                                <div className="publication-authors-titles">
-                                    {renderPublicationLink(publication, <p>{publication.authors}</p>, onPublicationLinkClick)}
-                                    {renderPublicationLink(publication, <p>{publication.theme}</p>, onPublicationLinkClick)}
+                                <div className="publication-primary-row">
+                                    <div className="publication-authors-titles">
+                                        {renderPublicationLink(
+                                            publication,
+                                            <p>
+                                                {publication.authors} {publication.theme}
+                                            </p>,
+                                            onPublicationLinkClick
+                                        )}
+                                    </div>
+                                    <button
+                                        aria-label="Скопировать ссылку в формате ГОСТ"
+                                        className="publication-copy-button"
+                                        onClick={() => onCopyPublicationGost(publication)}
+                                        title="Скопировать ссылку в формате ГОСТ"
+                                        type="button"
+                                    >
+                                        ⧉
+                                    </button>
                                 </div>
                                 {renderPublicationLink(
                                     publication,
@@ -125,9 +182,14 @@ function page(
                                 )}
                             </div>
                         ))}
-                    </div>
+                    </section>
                 ))}
             </div>
+            {toastMessage && (
+                <div aria-live="polite" className="publication-toast" role="status">
+                    {toastMessage}
+                </div>
+            )}
 
             {doiChoice && (
                 <>
@@ -170,6 +232,26 @@ function page(
             )}
         </main>
     );
+}
+
+function formatPublicationGost(publication: PublicationModel): string {
+    const authors = publication.authors.trim();
+    const title = publication.theme.trim();
+    const output = publication.published.trim();
+    const rawLink = publication.link.trim();
+    const resolvedLink = rawLink !== "" ? resolvePublicationLink(rawLink) : extractDoiUrl(output);
+
+    if (resolvedLink) {
+        return `${authors} ${title} // ${output} [Электронный ресурс]. URL: ${resolvedLink} (дата обращения: ${formatAccessDate(new Date())}).`;
+    }
+    return `${authors} ${title} // ${output}.`;
+}
+
+function formatAccessDate(value: Date): string {
+    const day = `${value.getDate()}`.padStart(2, "0");
+    const month = `${value.getMonth() + 1}`.padStart(2, "0");
+    const year = value.getFullYear();
+    return `${day}.${month}.${year}`;
 }
 
 function extractDoiUrl(text: string): string | null {

--- a/src/view/pages/works/WorksView.tsx
+++ b/src/view/pages/works/WorksView.tsx
@@ -41,14 +41,17 @@ function page(worksData: WorksByProjectTypeDto[] | null, isLoading: boolean, err
         <main>
             <Breadcrumbs items={[{label: "Главная", to: "/home"}, {label: "Студенческие работы"}]}/>
             <div className="works-page">
-                <h1>Дипломные работы и диссертации</h1>
+                <section className="works-hero">
+                    <h1>Дипломные работы и диссертации</h1>
+                    <p>Подборка студенческих и исследовательских работ по процесс-ориентированному программированию.</p>
+                </section>
                 {isLoading && <p className="remote-data-state">Загрузка работ...</p>}
                 {error && <p className="remote-data-state remote-data-state-error">Не удалось загрузить работы: {error}</p>}
                 {!isLoading && !error && worksData?.length === 0 && (
                     <p className="remote-data-state">Работы пока не найдены.</p>
                 )}
                 {worksData?.map((worksClassModel: WorksByProjectTypeDto) => (
-                    <div className="works-class section-spacer" id={worksClassModel.hash} key={worksClassModel.hash}>
+                    <section className="works-class section-spacer" id={worksClassModel.hash} key={worksClassModel.hash}>
                         <h2>{worksClassModel.title}</h2>
                         {worksClassModel.works.map((workModel: WorkModel, index: number) => (
                             <div
@@ -57,13 +60,12 @@ function page(worksData: WorksByProjectTypeDto[] | null, isLoading: boolean, err
                                 key={`${worksClassModel.hash}-${workModel.id}-${index}`}
                             >
                                 <div className="work-authors-titles">
-                                    <p>{workModel.authors}</p>
-                                    <p>{workModel.theme}</p>
+                                    <p>{workModel.authors} {workModel.theme}</p>
                                 </div>
                                 <p className="work-published">{workModel.published}</p>
                             </div>
                         ))}
-                    </div>
+                    </section>
                 ))}
             </div>
         </main>


### PR DESCRIPTION
## Что сделано
- Раздел Публикации приведен к единому визуальному стилю с разделом Проекты (hero, карточки по годам, единая сетка и отступы).
- В публикациях объединены авторы и название работы в одну последовательность для удобства чтения.
- Добавлено копирование библиографической записи в формате ГОСТ по кнопке у публикации.
- Уведомление о копировании переделано в компактный toast "Скопировано!" внизу экрана.
- В разделе Студенческие работы объединены авторы и название в одну последовательную строку с корректным переносом текста.

## Зачем
- Улучшить читаемость контента для студентов.
- Снизить время на ручное оформление источников при подготовке ВКР/отчетов.
- Привести ключевые контентные разделы к одному визуальному языку.
