### PR TITLE
fix(auth): require Keycloak sessions

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -13,44 +13,8 @@ function buildUrl(path: string): string {
     return `${apiBaseUrl}${path}`;
 }
 
-function getEnvDebugAuthHeaders(): Record<string, string> {
-    const enabled = import.meta.env.VITE_DEBUG_HEADERS_ENABLED === "true";
-    if (!enabled) {
-        return {};
-    }
-
-    const sub = import.meta.env.VITE_DEBUG_USER_SUB?.trim();
-    if (!sub) {
-        return {};
-    }
-
-    const headers: Record<string, string> = {
-        subject: sub
-    };
-
-    const email = import.meta.env.VITE_DEBUG_USER_EMAIL?.trim();
-    if (email) {
-        headers.email = email;
-    }
-
-    const name = import.meta.env.VITE_DEBUG_USER_NAME?.trim();
-    if (name) {
-        headers.name = name;
-    }
-
-    const roles = import.meta.env.VITE_DEBUG_USER_ROLES?.trim();
-    if (roles) {
-        headers.roles = roles;
-    }
-
-    return headers;
-}
-
 function getAuthHeaders(): Record<string, string> {
-    return {
-        ...getEnvDebugAuthHeaders(),
-        ...getLocalAuthHeaders()
-    };
+    return getLocalAuthHeaders();
 }
 
 function buildHeaders(headers?: HeadersInit): HeadersInit {

--- a/src/utils/localAuth.ts
+++ b/src/utils/localAuth.ts
@@ -6,24 +6,14 @@ export interface LocalAuthSession {
     email: string
     roles: string[]
     createdAt: string
-    accessToken?: string
+    accessToken: string
     refreshToken?: string
     expiresAt?: number
 }
 
-export interface LocalAuthUser {
-    name: string
-    email: string
-    password: string
-    roles: string[]
-    createdAt: string
-}
-
 const localAuthStorageKey = "poprog_local_auth_session";
-const localAuthUsersStorageKey = "poprog_local_auth_users";
+const legacyLocalAuthUsersStorageKey = "poprog_local_auth_users";
 export const localAuthChangedEventName = "poprog-auth-changed";
-const demoUserEmail = "developer@dev.com";
-const demoUserPassword = "developer";
 
 function isLocalAuthSession(value: unknown): value is LocalAuthSession {
     if (!value || typeof value !== "object") {
@@ -36,72 +26,9 @@ function isLocalAuthSession(value: unknown): value is LocalAuthSession {
         && typeof candidate.email === "string"
         && Array.isArray(candidate.roles)
         && typeof candidate.createdAt === "string"
-        && (candidate.accessToken === undefined || typeof candidate.accessToken === "string")
+        && typeof candidate.accessToken === "string"
         && (candidate.refreshToken === undefined || typeof candidate.refreshToken === "string")
         && (candidate.expiresAt === undefined || typeof candidate.expiresAt === "number");
-}
-
-function isLocalAuthUser(value: unknown): value is LocalAuthUser {
-    if (!value || typeof value !== "object") {
-        return false;
-    }
-
-    const candidate = value as Record<string, unknown>;
-    return typeof candidate.name === "string"
-        && typeof candidate.email === "string"
-        && typeof candidate.password === "string"
-        && Array.isArray(candidate.roles)
-        && typeof candidate.createdAt === "string";
-}
-
-function readLocalAuthUsersRaw(): LocalAuthUser[] {
-    if (typeof window === "undefined") {
-        return [];
-    }
-
-    const raw = window.localStorage.getItem(localAuthUsersStorageKey);
-    if (!raw) {
-        return [];
-    }
-
-    try {
-        const parsed: unknown = JSON.parse(raw);
-        if (!Array.isArray(parsed)) {
-            return [];
-        }
-        return parsed.filter(isLocalAuthUser);
-    } catch {
-        return [];
-    }
-}
-
-function saveLocalAuthUsers(users: LocalAuthUser[]): void {
-    if (typeof window === "undefined") {
-        return;
-    }
-
-    window.localStorage.setItem(localAuthUsersStorageKey, JSON.stringify(users));
-}
-
-function ensureDemoUser(): void {
-    if (typeof window === "undefined") {
-        return;
-    }
-
-    const users = readLocalAuthUsersRaw();
-    const hasDemoUser = users.some((user) => user.email.toLowerCase() === demoUserEmail);
-    if (hasDemoUser) {
-        return;
-    }
-
-    users.push({
-        name: "Developer",
-        email: demoUserEmail,
-        password: demoUserPassword,
-        roles: ["USER", "DEVOPS"],
-        createdAt: new Date().toISOString()
-    });
-    saveLocalAuthUsers(users);
 }
 
 function emitAuthChanged(): void {
@@ -112,8 +39,6 @@ function emitAuthChanged(): void {
 }
 
 export function readLocalAuthSession(): LocalAuthSession | null {
-    ensureDemoUser();
-
     if (typeof window === "undefined") {
         return null;
     }
@@ -125,8 +50,13 @@ export function readLocalAuthSession(): LocalAuthSession | null {
 
     try {
         const parsed: unknown = JSON.parse(raw);
-        return isLocalAuthSession(parsed) ? parsed : null;
+        if (!isLocalAuthSession(parsed)) {
+            clearLocalAuthSession();
+            return null;
+        }
+        return parsed;
     } catch {
+        clearLocalAuthSession();
         return null;
     }
 }
@@ -137,6 +67,7 @@ export function saveLocalAuthSession(session: LocalAuthSession): void {
     }
 
     window.localStorage.setItem(localAuthStorageKey, JSON.stringify(session));
+    window.localStorage.removeItem(legacyLocalAuthUsersStorageKey);
     emitAuthChanged();
 }
 
@@ -146,39 +77,8 @@ export function clearLocalAuthSession(): void {
     }
 
     window.localStorage.removeItem(localAuthStorageKey);
+    window.localStorage.removeItem(legacyLocalAuthUsersStorageKey);
     emitAuthChanged();
-}
-
-export function deleteLocalAuthCurrentAccount(): boolean {
-    const currentSession = readLocalAuthSession();
-    if (!currentSession) {
-        return false;
-    }
-
-    const currentEmailNormalized = currentSession.email.trim().toLowerCase();
-    const users = readLocalAuthUsersRaw();
-    const filteredUsers = users.filter((user) => user.email.toLowerCase() !== currentEmailNormalized);
-
-    if (filteredUsers.length !== users.length) {
-        saveLocalAuthUsers(filteredUsers);
-    }
-
-    clearLocalAuthSession();
-    return true;
-}
-
-export function createLocalAuthSession(name: string, email: string, mode: AuthMode, roles: string[] = ["USER"]): LocalAuthSession {
-    const normalizedEmail = email.trim().toLowerCase();
-    const normalizedName = name.trim();
-    const subjectPrefix = mode === "register" ? "reg" : "login";
-
-    return {
-        subject: `${subjectPrefix}-${normalizedEmail.replace(/[^a-z0-9@._-]/g, "-")}`,
-        name: normalizedName,
-        email: normalizedEmail,
-        roles,
-        createdAt: new Date().toISOString()
-    };
 }
 
 export function getLocalAuthHeaders(): Record<string, string> {
@@ -187,64 +87,20 @@ export function getLocalAuthHeaders(): Record<string, string> {
         return {};
     }
 
-    if (session.accessToken) {
-        return {
-            Authorization: `Bearer ${session.accessToken}`
-        };
-    }
-
     return {
-        subject: session.subject,
-        email: session.email,
-        name: session.name,
-        roles: session.roles.join(",")
+        Authorization: `Bearer ${session.accessToken}`
     };
-}
-
-export function registerLocalAuthUser(name: string, email: string, password: string, roles: string[] = ["USER"]): LocalAuthUser {
-    ensureDemoUser();
-
-    const normalizedEmail = email.trim().toLowerCase();
-    const normalizedName = name.trim();
-    const normalizedPassword = password.trim();
-
-    const users = readLocalAuthUsersRaw();
-    const hasDuplicate = users.some((user) => user.email.toLowerCase() === normalizedEmail);
-    if (hasDuplicate) {
-        throw new Error("Пользователь с таким email уже зарегистрирован.");
-    }
-
-    const user: LocalAuthUser = {
-        name: normalizedName,
-        email: normalizedEmail,
-        password: normalizedPassword,
-        roles,
-        createdAt: new Date().toISOString()
-    };
-    users.push(user);
-    saveLocalAuthUsers(users);
-    return user;
-}
-
-export function findLocalAuthUserByCredentials(email: string, password: string): LocalAuthUser | null {
-    ensureDemoUser();
-
-    const normalizedEmail = email.trim().toLowerCase();
-    const normalizedPassword = password.trim();
-    const users = readLocalAuthUsersRaw();
-
-    const user = users.find((candidate) => (
-        candidate.email.toLowerCase() === normalizedEmail
-        && candidate.password === normalizedPassword
-    ));
-
-    return user ?? null;
 }
 
 interface KeycloakTokenResponse {
     access_token: string
     refresh_token?: string
     expires_in?: number
+}
+
+interface KeycloakErrorResponse {
+    error?: string
+    error_description?: string
 }
 
 interface KeycloakJwtClaims {
@@ -312,6 +168,31 @@ function collectKeycloakRoles(claims: KeycloakJwtClaims, clientId: string): stri
     return Array.from(roles);
 }
 
+async function resolveKeycloakLoginError(response: Response): Promise<Error> {
+    let details: KeycloakErrorResponse | null = null;
+    try {
+        details = await response.json() as KeycloakErrorResponse;
+    } catch {
+        details = null;
+    }
+
+    const description = details?.error_description?.toLowerCase() ?? "";
+
+    if (description.includes("account is not fully set up") || description.includes("update_password")) {
+        return new Error("Пароль в Keycloak помечен как временный. Зайдите в Keycloak напрямую и завершите смену пароля либо в админке задайте пароль с Temporary = Off.");
+    }
+
+    if (description.includes("invalid user credentials")) {
+        return new Error("Неверный логин или пароль.");
+    }
+
+    if (details?.error === "unauthorized_client") {
+        return new Error("Клиент Keycloak не разрешает вход по паролю. Проверьте Direct Access Grants для клиента портала.");
+    }
+
+    return new Error("Keycloak отклонил вход. Проверьте пароль, realm пользователя и required actions в профиле Keycloak.");
+}
+
 export async function loginKeycloakAccount(email: string, password: string): Promise<LocalAuthSession> {
     const clientId = resolveKeycloakClientId();
     const body = new URLSearchParams({
@@ -330,7 +211,7 @@ export async function loginKeycloakAccount(email: string, password: string): Pro
     });
 
     if (!response.ok) {
-        throw new Error("Неверный логин или пароль.");
+        throw await resolveKeycloakLoginError(response);
     }
 
     const tokenResponse = await response.json() as KeycloakTokenResponse;
@@ -350,32 +231,4 @@ export async function loginKeycloakAccount(email: string, password: string): Pro
         refreshToken: tokenResponse.refresh_token,
         expiresAt: tokenResponse.expires_in ? Date.now() + tokenResponse.expires_in * 1000 : undefined
     };
-}
-
-export function updateLocalAuthSessionProfile(name: string, email: string): LocalAuthSession | null {
-    const currentSession = readLocalAuthSession();
-    if (!currentSession) {
-        return null;
-    }
-
-    const nextSession: LocalAuthSession = {
-        ...currentSession,
-        name: name.trim(),
-        email: email.trim().toLowerCase()
-    };
-    saveLocalAuthSession(nextSession);
-
-    const users = readLocalAuthUsersRaw();
-    const currentEmailNormalized = currentSession.email.trim().toLowerCase();
-    const targetUserIndex = users.findIndex((user) => user.email.toLowerCase() === currentEmailNormalized);
-    if (targetUserIndex >= 0) {
-        users[targetUserIndex] = {
-            ...users[targetUserIndex],
-            name: nextSession.name,
-            email: nextSession.email
-        };
-        saveLocalAuthUsers(users);
-    }
-
-    return nextSession;
 }

--- a/src/view/pages/account/AccountView.tsx
+++ b/src/view/pages/account/AccountView.tsx
@@ -21,22 +21,17 @@ import type {
     AccountProfileResponse
 } from "../../../api/types";
 import {
-    createLocalAuthSession,
-    deleteLocalAuthCurrentAccount,
-    findLocalAuthUserByCredentials,
+    clearLocalAuthSession,
     loginKeycloakAccount,
     localAuthChangedEventName,
     readLocalAuthSession,
-    registerLocalAuthUser,
     saveLocalAuthSession,
-    updateLocalAuthSessionProfile,
     type AuthMode,
     type LocalAuthSession
 } from "../../../utils/localAuth";
 import "../../../styles/pages/Account.scss";
 
 const serviceRoles = new Set(["ADMIN", "MODERATOR", "SUPPORT", "DEVOPS", "PM", "EDITOR"]);
-const localRoleOptions = ["USER", "ADMIN", "SUPPORT", "PM", "DEVOPS"];
 
 function buildProfileFromSession(session: LocalAuthSession): AccountProfileResponse {
     return {
@@ -59,7 +54,6 @@ export function AccountView() {
     const [authName, setAuthName] = useState("");
     const [authEmail, setAuthEmail] = useState("");
     const [authPassword, setAuthPassword] = useState("");
-    const [authRole, setAuthRole] = useState("USER");
     const [authError, setAuthError] = useState("");
     const [isAuthSubmitting, setIsAuthSubmitting] = useState(false);
     const [profile, setProfile] = useState<AccountProfileResponse | null>(() => {
@@ -84,8 +78,6 @@ export function AccountView() {
     const hasServiceRole = (profile?.roles ?? []).some((role) => serviceRoles.has(role.toUpperCase()));
     const hasAdminRole = (profile?.roles ?? []).some((role) => role.toUpperCase() === "ADMIN");
     const profileSubject = profile?.subject ?? "";
-    const isLocalRoleDebugVisible = typeof window !== "undefined"
-        && ["localhost", "127.0.0.1"].includes(window.location.hostname);
 
     useEffect(() => {
         setAuthMode(getAuthModeFromSearch(location.search));
@@ -174,7 +166,7 @@ export function AccountView() {
     const authHint = useMemo(() => (
         authMode === "register"
             ? "Создайте аккаунт в интерфейсе Poprog, чтобы сохранять избранное и историю операций."
-            : "Войдите в аккаунт Poprog, чтобы открыть личный кабинет без внешнего редиректа. Демо: developer@dev.com / developer"
+            : "Войдите в аккаунт Poprog через Keycloak, чтобы открыть личный кабинет без внешнего редиректа."
     ), [authMode]);
 
     const switchAuthMode = (mode: AuthMode) => {
@@ -207,61 +199,19 @@ export function AccountView() {
             let session: LocalAuthSession;
 
             if (authMode === "login") {
-                try {
-                    session = await loginKeycloakAccount(normalizedEmail, authPassword);
-                } catch {
-                    const foundUser = findLocalAuthUserByCredentials(normalizedEmail, authPassword);
-                    if (!foundUser) {
-                        setAuthError("Неверный логин или пароль.");
-                        return;
-                    }
-
-                    session = createLocalAuthSession(foundUser.name, foundUser.email, "login", foundUser.roles);
-                }
+                session = await loginKeycloakAccount(normalizedEmail, authPassword);
             } else {
                 if (normalizedName.length < 2) {
                     setAuthError("Введите имя не короче 2 символов.");
                     return;
                 }
 
-                try {
-                    const registeredProfile = await registerAccount({
-                        name: normalizedName,
-                        email: normalizedEmail,
-                        password: authPassword
-                    });
-
-                    try {
-                        session = await loginKeycloakAccount(normalizedEmail, authPassword);
-                    } catch {
-                        session = {
-                            subject: registeredProfile.subject,
-                            name: registeredProfile.name,
-                            email: registeredProfile.email,
-                            roles: registeredProfile.roles,
-                            createdAt: new Date().toISOString()
-                        };
-                    }
-                } catch (registrationError) {
-                    if (!isLocalRoleDebugVisible) {
-                        setAuthError(registrationError instanceof Error ? registrationError.message : "Не удалось создать аккаунт в Keycloak.");
-                        return;
-                    }
-
-                    registerLocalAuthUser(
-                        normalizedName,
-                        normalizedEmail,
-                        authPassword,
-                        isLocalRoleDebugVisible ? [authRole] : ["USER"]
-                    );
-
-                    session = createLocalAuthSession(
-                        normalizedName,
-                        normalizedEmail,
-                        "register",
-                        isLocalRoleDebugVisible ? [authRole] : ["USER"]
-                    );
-                }
+                await registerAccount({
+                    name: normalizedName,
+                    email: normalizedEmail,
+                    password: authPassword
+                });
+                session = await loginKeycloakAccount(normalizedEmail, authPassword);
             }
 
             saveLocalAuthSession(session);
@@ -297,12 +247,7 @@ export function AccountView() {
         setDeleteAccountError("");
 
         try {
-            const isDeleted = deleteLocalAuthCurrentAccount();
-            if (!isDeleted) {
-                setDeleteAccountError("Не удалось удалить аккаунт. Попробуйте войти заново.");
-                return;
-            }
-
+            clearLocalAuthSession();
             setProfile(null);
             setChats([]);
             setFavorites([]);
@@ -345,14 +290,8 @@ export function AccountView() {
             });
             setProfile(updatedProfile);
             setIsProfileEditing(false);
-        } catch {
-            const localSession = updateLocalAuthSessionProfile(normalizedName, normalizedEmail);
-            if (localSession) {
-                setProfile(buildProfileFromSession(localSession));
-                setIsProfileEditing(false);
-            } else {
-                setProfileEditError("Не удалось сохранить профиль.");
-            }
+        } catch (saveError) {
+            setProfileEditError(saveError instanceof Error ? saveError.message : "Не удалось сохранить профиль.");
         } finally {
             setIsSavingProfile(false);
         }
@@ -479,17 +418,6 @@ export function AccountView() {
                                 />
                             </label>
 
-                            {isLocalRoleDebugVisible && (
-                                <label>
-                                    Служебная роль для локальной отладки
-                                    <select onChange={(event) => setAuthRole(event.target.value)} value={authRole}>
-                                        {localRoleOptions.map((role) => (
-                                            <option key={role} value={role}>{role}</option>
-                                        ))}
-                                    </select>
-                                </label>
-                            )}
-
                             {authError.length > 0 && <p className="account-auth-error">{authError}</p>}
 
                             <button className="account-auth-submit" disabled={isAuthSubmitting} type="submit">
@@ -500,8 +428,7 @@ export function AccountView() {
                         </form>
 
                         <p className="account-auth-note">
-                            Тестовый вход: <strong>developer@dev.com</strong> / <strong>developer</strong><br/>
-                            После входа вы сможете управлять историей донатов, сохранять избранные материалы и переходить в чаты.
+                            После входа через Keycloak вы сможете управлять историей донатов, сохранять избранные материалы и переходить в чаты.
                             <Link to="/donate"> Поддержать проект</Link>
                         </p>
                     </div>
@@ -526,7 +453,7 @@ export function AccountView() {
                                 )}
                                 {!hasAdminRole && (
                                     <button className="account-danger-action-button" onClick={openDeleteAccountModal} type="button">
-                                        Удалить аккаунт
+                                        Выйти
                                     </button>
                                 )}
                             </div>
@@ -675,8 +602,8 @@ export function AccountView() {
                                 onClick={(event) => event.stopPropagation()}
                                 role="dialog"
                             >
-                                <h3 id="account-delete-title">Удалить аккаунт?</h3>
-                                <p>Это действие необратимо: профиль и локальная сессия будут удалены.</p>
+                                <h3 id="account-delete-title">Выйти из аккаунта?</h3>
+                                <p>Текущая сессия будет завершена на этом устройстве. Учетная запись в Keycloak сохранится.</p>
                                 {deleteAccountError.length > 0 && <p className="account-auth-error">{deleteAccountError}</p>}
                                 <div className="account-modal-actions">
                                     <button className="account-modal-secondary-button" onClick={closeDeleteAccountModal} type="button">
@@ -688,7 +615,7 @@ export function AccountView() {
                                         onClick={handleDeleteAccount}
                                         type="button"
                                     >
-                                        {isDeletingAccount ? "Удаляем..." : "Удалить аккаунт"}
+                                        {isDeletingAccount ? "Выходим..." : "Выйти"}
                                     </button>
                                 </div>
                             </section>

--- a/src/view/pages/account/AdminDonationsView.tsx
+++ b/src/view/pages/account/AdminDonationsView.tsx
@@ -143,7 +143,7 @@ export function AdminDonationsView() {
             {profile && !hasAccess && (
                 <section className="account-card">
                     <h1>Админ-донаты</h1>
-                    <p>Эта страница доступна только для служебных ролей. Для локальной отладки войдите под ролью `ADMIN` или `SUPPORT`.</p>
+                    <p>Эта страница доступна только для служебных ролей. Выдайте пользователю роль `ADMIN` или `SUPPORT` в Keycloak.</p>
                     <Link className="account-inline-link" to="/account">Вернуться в личный кабинет</Link>
                 </section>
             )}


### PR DESCRIPTION
## Summary\n- remove demo/local users and password fallback from account login and registration\n- require Keycloak token sessions for API authorization instead of dev/local headers\n- update account/admin copy so local testing uses Keycloak roles\n\n## Verification\n- npm test\n- npm run build\n- verified production bundle markers are removed locally: no developer@dev.com or VITE_DEBUG_HEADERS, Keycloak grant_type remains\n