### PR TITLE
[codex] Add project documentation pages

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import {Home} from "./view/pages/home/Home";
 import {ChatView} from "./view/pages/chat/ChatView";
 import {ProjectsView} from "./view/pages/projects/ProjectsView";
 import {ProjectItemView} from "./view/pages/projects/ProjectItemView";
+import {ProjectDocsView} from "./view/pages/projects/ProjectDocsView";
 import {MarketView} from "./view/pages/market/MarketView";
 import {AccountView} from "./view/pages/account/AccountView";
 import {AdminDonationsView} from "./view/pages/account/AdminDonationsView";
@@ -56,6 +57,10 @@ const router = createBrowserRouter([
     {
         path: "/projects",
         element: <ProjectsView/>
+    },
+    {
+        path: "/projects/:itemSlug/docs",
+        element: <ProjectDocsView/>
     },
     {
         path: "/projects/:itemSlug",

--- a/src/styles/common/Breadcrumbs.scss
+++ b/src/styles/common/Breadcrumbs.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  color: #4f5565;
+  color: #5f5f5f;
   font-size: 0.92rem;
 }
 
@@ -15,21 +15,22 @@
 }
 
 .site-breadcrumbs-item a {
-  color: #2f4eaa;
+  color: #303030;
   text-decoration: none;
 }
 
 .site-breadcrumbs-item a:hover {
+  color: #000;
   text-decoration: underline;
 }
 
 .site-breadcrumbs-item span[aria-current="page"] {
-  color: #151515;
+  color: #111;
   font-weight: 700;
 }
 
 .site-breadcrumbs-separator {
-  color: #8e93a2;
+  color: #9a9a9a;
 }
 
 @media (max-width: 720px) {

--- a/src/styles/pages/Projects.scss
+++ b/src/styles/pages/Projects.scss
@@ -217,3 +217,170 @@
     align-items: flex-start;
   }
 }
+
+.project-docs-layout {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(210px, 260px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.project-docs-sidebar,
+.project-docs-content,
+.project-docs-section,
+.project-docs-links {
+  border: 1px solid #d9d9d9;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(20, 20, 20, 0.06);
+}
+
+.project-docs-sidebar {
+  position: sticky;
+  top: 92px;
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 18px;
+}
+
+.project-docs-sidebar h2 {
+  margin: 4px 0 0;
+  font-size: 1rem;
+}
+
+.project-docs-sidebar a {
+  color: #202020;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.project-docs-sidebar a:hover {
+  text-decoration: underline;
+}
+
+.project-docs-status {
+  width: fit-content;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.project-docs-status-ready {
+  border: 1px solid #b7dfc5;
+  background: #e8f7ee;
+  color: #1f6f3c;
+}
+
+.project-docs-status-draft {
+  border: 1px solid #efd58e;
+  background: #fff3d7;
+  color: #8a5200;
+}
+
+.project-docs-content {
+  display: grid;
+  gap: 12px;
+  border-radius: 20px;
+  padding: 14px;
+}
+
+.project-docs-hero {
+  border: 1px solid #1f1f1f;
+  border-radius: 18px;
+  padding: 20px;
+  color: #fff;
+  background:
+    radial-gradient(circle at 18% 18%, rgba(255, 255, 255, 0.18), transparent 28%),
+    linear-gradient(130deg, #111 0%, #3d3d3d 100%);
+}
+
+.project-docs-hero span {
+  display: inline-block;
+  margin-bottom: 8px;
+  font-size: 0.84rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.project-docs-hero h1,
+.project-docs-hero p,
+.project-docs-section h2,
+.project-docs-section p,
+.project-docs-section ul,
+.project-docs-links h2 {
+  margin: 0;
+}
+
+.project-docs-hero h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.project-docs-hero p {
+  max-width: 74ch;
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.project-docs-section,
+.project-docs-links {
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.project-docs-section {
+  display: grid;
+  gap: 10px;
+  scroll-margin-top: 112px;
+}
+
+.project-docs-section p,
+.project-docs-section li {
+  color: #515151;
+}
+
+.project-docs-section ul {
+  display: grid;
+  gap: 6px;
+  padding-left: 20px;
+}
+
+.project-docs-links {
+  display: grid;
+  gap: 12px;
+}
+
+.project-docs-links div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.project-docs-links a {
+  border: 1px solid #151515;
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: #151515;
+  color: #fff;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.project-docs-links a:nth-child(even) {
+  border-color: #4f4f4f;
+  background: #4f4f4f;
+}
+
+@media (max-width: 820px) {
+  .project-docs-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .project-docs-sidebar {
+    position: static;
+  }
+}

--- a/src/view/pages/projects/ProjectDocsView.tsx
+++ b/src/view/pages/projects/ProjectDocsView.tsx
@@ -1,0 +1,216 @@
+import {useMemo} from "react";
+import {Link, useParams} from "react-router-dom";
+import BodyView from "../BodyView";
+import {Breadcrumbs} from "../../common/navigation/Breadcrumbs";
+import "../../../styles/pages/Projects.scss";
+
+type ProjectDocsStatus = "ready" | "draft";
+
+interface ProjectDocsSection {
+    id: string
+    title: string
+    body: string
+    bullets: string[]
+}
+
+interface ProjectDocsLink {
+    label: string
+    to: string
+}
+
+interface ProjectDocsContent {
+    title: string
+    status: ProjectDocsStatus
+    summary: string
+    sections: ProjectDocsSection[]
+    links: ProjectDocsLink[]
+}
+
+const coreLinks: ProjectDocsLink[] = [
+    {label: "Публикации", to: "/publications"},
+    {label: "Студенческие работы", to: "/works"},
+    {label: "Видео", to: "/video"},
+    {label: "Задать вопрос ИИ", to: "/chat"}
+];
+
+const projectDocsMap: Record<string, ProjectDocsContent> = {
+    reflex: {
+        title: "Reflex",
+        status: "ready",
+        summary: "Документация по процесс-ориентированному языку Reflex: модель процессов, события, сценарии запуска и дальнейшее изучение.",
+        sections: [
+            {
+                id: "overview",
+                title: "Назначение",
+                body: "Reflex используется для описания управляющего программного обеспечения через процессы и события, чтобы поведение системы было проще читать, проверять и сопровождать.",
+                bullets: ["процессная модель вместо неявной логики состояний", "подходит для embedded и промышленной автоматизации", "удобен как точка входа в технологии Poprog"]
+            },
+            {
+                id: "start",
+                title: "Быстрый старт",
+                body: "Начинать лучше с обзора модели исполнения, затем перейти к простому процессу, обработке событий и диагностике типовых ошибок.",
+                bullets: ["изучить базовые конструкции языка", "разобрать пример управляющего процесса", "связать пример с публикациями и учебными работами"]
+            },
+            {
+                id: "materials",
+                title: "Материалы",
+                body: "Раздел собирает ссылки на материалы портала, которые помогают перейти от знакомства с языком к практическому применению.",
+                bullets: ["научные публикации по Reflex", "студенческие работы и демонстрационные проекты", "видеоматериалы и ответы ИИ-агента"]
+            }
+        ],
+        links: coreLinks
+    },
+    post: {
+        title: "poST",
+        status: "ready",
+        summary: "Документация по poST как процесс-ориентированному расширению Structured Text для команд, работающих с ПЛК и IEC 61131-3.",
+        sections: [
+            {
+                id: "overview",
+                title: "Назначение",
+                body: "poST помогает описывать параллельные и событийные сценарии в привычной для автоматизации ST-парадигме, но с более явной процессной структурой.",
+                bullets: ["связь с IEC 61131-3 Structured Text", "описание параллельных процессов", "снижение риска гонок состояний"]
+            },
+            {
+                id: "start",
+                title: "Быстрый старт",
+                body: "Для первого знакомства полезно сравнить типовой ST-фрагмент с poST-представлением и посмотреть, какие состояния становятся явными.",
+                bullets: ["выбрать небольшой ST-сценарий", "выделить процессы и события", "проверить сценарий через материалы портала"]
+            },
+            {
+                id: "materials",
+                title: "Материалы",
+                body: "Связанные материалы будут расширяться по мере наполнения базы знаний и появления новых демонстраций.",
+                bullets: ["публикации по poST", "учебные и выпускные работы", "релизные заметки и видеообзоры"]
+            }
+        ],
+        links: coreLinks
+    },
+    "industrial-c": {
+        title: "IndustrialC",
+        status: "draft",
+        summary: "Черновой центр документации по IndustrialC: промышленная автоматизация, real-time контуры и безопасные инженерные практики.",
+        sections: [
+            {
+                id: "overview",
+                title: "Назначение",
+                body: "IndustrialC ориентирован на команды, которым нужна гибкость C вместе с доменными ограничениями и практиками промышленной разработки.",
+                bullets: ["низкоуровневый контроль исполнения", "фокус на надежности промышленных контуров", "интеграция с существующими цепочками сборки"]
+            },
+            {
+                id: "start",
+                title: "Что будет добавлено",
+                body: "Раздел готовится как точка входа: обзор языка, требования к окружению, примеры и ссылки на связанные материалы.",
+                bullets: ["первый пример IndustrialC", "гайд по запуску окружения", "связанные публикации и учебные работы"]
+            },
+            {
+                id: "materials",
+                title: "Связанные разделы",
+                body: "Пока документация неполная, пользователь не должен попадать в тупик: доступны поиск, публикации, работы и чат.",
+                bullets: ["искать материалы по IndustrialC", "задать вопрос ИИ-агенту", "перейти к общему каталогу проектов"]
+            }
+        ],
+        links: coreLinks
+    }
+};
+
+const genericDocsTitles: Record<string, string> = {
+    "languages-whats-new": "Что нового в языках",
+    "ride-overview": "RIDE",
+    "ride-cloud-launch": "Запуск RIDE в облаке",
+    "ride-debug": "Инструменты отладки RIDE",
+    "ride-whats-new": "Что нового в RIDE",
+    requirements: "Требования",
+    traceability: "Трассировка",
+    "edtl-spec": "EDTL-спецификации",
+    "edtl-whats-new": "Что нового в EDTL",
+    "architecture-templates": "Шаблоны архитектур",
+    "communication-modules": "Модули связи",
+    "typical-solutions": "Типовые решения",
+    "distributed-whats-new": "Что нового в распределенных системах",
+    "code-checks": "Проверки кода",
+    "quality-metrics": "Метрики качества",
+    "analysis-reports": "Отчеты анализа",
+    "analysis-whats-new": "Что нового в анализе"
+};
+
+function buildDraftDocs(slug: string): ProjectDocsContent {
+    const title = genericDocsTitles[slug] ?? "Проект";
+
+    return {
+        title,
+        status: "draft",
+        summary: `Документация раздела «${title}» готовится. Вместо общей инструкции портала здесь показана проектная точка входа и быстрые переходы к связанным материалам.`,
+        sections: [
+            {
+                id: "scope",
+                title: "Что будет в разделе",
+                body: "На этой странице будут собраны пользовательские инструкции, архитектурные заметки, демонстрационные сценарии и ссылки на материалы базы знаний.",
+                bullets: ["назначение проекта или технологии", "первые шаги для пользователя", "ссылки на публикации, работы, видео и поддержку"]
+            },
+            {
+                id: "current",
+                title: "Текущий статус",
+                body: "Пока содержимое не наполнено, пользователь остается в контексте выбранного проекта и может перейти в смежные разделы, а не на общую страницу-заглушку.",
+                bullets: ["не теряется выбранная технология", "виден статус подготовки", "доступны быстрые действия"]
+            }
+        ],
+        links: [
+            {label: "Все проекты", to: "/projects"},
+            {label: "Поддержка", to: "/support"},
+            {label: "Связаться с нами", to: "/contact"},
+            {label: "Задать вопрос ИИ", to: "/chat"}
+        ]
+    };
+}
+
+export function ProjectDocsView() {
+    const {itemSlug = ""} = useParams();
+    const content = useMemo(() => projectDocsMap[itemSlug] ?? buildDraftDocs(itemSlug), [itemSlug]);
+    const statusLabel = content.status === "ready" ? "Документация доступна" : "Раздел готовится";
+
+    return BodyView(
+        <main className="projects-page project-docs-page">
+            <Breadcrumbs items={[
+                {label: "Главная", to: "/home"},
+                {label: "Проекты", to: "/projects"},
+                {label: content.title, to: `/projects/${itemSlug}`},
+                {label: "Документация"}
+            ]}/>
+
+            <section className="project-docs-layout">
+                <aside className="project-docs-sidebar" aria-label="Навигация по документации проекта">
+                    <span className={`project-docs-status project-docs-status-${content.status}`}>{statusLabel}</span>
+                    {content.sections.map((section) => (
+                        <a href={`#${section.id}`} key={section.id}>{section.title}</a>
+                    ))}
+                </aside>
+
+                <article className="project-docs-content">
+                    <header className="project-docs-hero">
+                        <span>Документация проекта</span>
+                        <h1>{content.title}</h1>
+                        <p>{content.summary}</p>
+                    </header>
+
+                    {content.sections.map((section) => (
+                        <section className="project-docs-section" id={section.id} key={section.id}>
+                            <h2>{section.title}</h2>
+                            <p>{section.body}</p>
+                            <ul>
+                                {section.bullets.map((bullet) => <li key={bullet}>{bullet}</li>)}
+                            </ul>
+                        </section>
+                    ))}
+
+                    <section className="project-docs-links" aria-label="Связанные разделы">
+                        <h2>Быстрые переходы</h2>
+                        <div>
+                            {content.links.map((link) => <Link key={link.to} to={link.to}>{link.label}</Link>)}
+                        </div>
+                    </section>
+                </article>
+            </section>
+        </main>
+    );
+}

--- a/src/view/pages/projects/ProjectItemView.tsx
+++ b/src/view/pages/projects/ProjectItemView.tsx
@@ -29,8 +29,8 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Прозрачность архитектуры контроллерного ПО",
             "Быстрый онбординг новых инженеров"
         ],
-        cta: "Запросить демо-пакет Reflex",
-        ctaPath: "/contact"
+        cta: "Открыть документацию Reflex",
+        ctaPath: "/projects/reflex/docs"
     },
     post: {
         title: "poST",
@@ -46,8 +46,8 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Сокращение аварий из-за гонок состояний",
             "Повторное использование типовых паттернов"
         ],
-        cta: "Получить гайд по poST",
-        ctaPath: "/docs"
+        cta: "Открыть документацию poST",
+        ctaPath: "/projects/post/docs"
     },
     "industrial-c": {
         title: "IndustrialC",
@@ -63,8 +63,8 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Упрощение сопровождения legacy-частей",
             "Единый стиль кода для команд автоматизации"
         ],
-        cta: "Запустить пилот IndustrialC",
-        ctaPath: "/contact"
+        cta: "Открыть документацию IndustrialC",
+        ctaPath: "/projects/industrial-c/docs"
     },
     "languages-whats-new": {
         title: "Что нового в языках",
@@ -115,7 +115,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Более предсказуемые релизы"
         ],
         cta: "Открыть раздел документации RIDE",
-        ctaPath: "/docs"
+        ctaPath: "/projects/ride-overview/docs"
     },
     "ride-cloud-launch": {
         title: "Запуск в облаке",
@@ -166,7 +166,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Более короткий цикл обратной связи"
         ],
         cta: "Посмотреть релиз-ноты",
-        ctaPath: "/docs"
+        ctaPath: "/projects/ride-whats-new/docs"
     },
     requirements: {
         title: "Требования",
@@ -183,7 +183,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Улучшение качества планирования релизов"
         ],
         cta: "Открыть материалы по требованиям",
-        ctaPath: "/docs"
+        ctaPath: "/projects/requirements/docs"
     },
     traceability: {
         title: "Трассировка",
@@ -217,7 +217,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Повышение доверия к итоговым релизам"
         ],
         cta: "Изучить документацию EDTL",
-        ctaPath: "/docs"
+        ctaPath: "/projects/edtl-spec/docs"
     },
     "edtl-whats-new": {
         title: "Что нового в EDTL",
@@ -302,7 +302,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Быстрее адаптация под новые требования"
         ],
         cta: "Изучить обновления",
-        ctaPath: "/docs"
+        ctaPath: "/projects/distributed-whats-new/docs"
     },
     "code-checks": {
         title: "Проверки кода",
@@ -319,7 +319,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Более предсказуемый CI-процесс"
         ],
         cta: "Открыть документацию по проверкам",
-        ctaPath: "/docs"
+        ctaPath: "/projects/code-checks/docs"
     },
     "quality-metrics": {
         title: "Метрики качества",
@@ -370,7 +370,7 @@ const projectContentMap: Record<string, ProjectContent> = {
             "Прозрачность для всей команды доставки"
         ],
         cta: "Читать релиз-заметки",
-        ctaPath: "/docs"
+        ctaPath: "/projects/analysis-whats-new/docs"
     }
 };
 


### PR DESCRIPTION
## Что изменилось

- Добавлена отдельная страница проектной документации `/projects/:itemSlug/docs`.
- Переведены CTA проектных карточек с общей `/docs` на документацию конкретного проекта.
- Добавлена проектная документация для Reflex, poST, IndustrialC и draft-состояния для остальных направлений.
- Хлебные крошки и корпус документации приведены к нейтральной серой палитре, при этом статус готовности оставляет цветовую семантику.
- Исправлены якорные переходы в содержании через `scroll-margin-top`, чтобы секции не прятались под фиксированной шапкой.

## Зачем

Пользователь при переходе к документации технологии больше не попадает на общую инструкцию портала. Вместо этого он остается в контексте конкретного проекта и видит понятные быстрые переходы к связанным материалам.

## Проверка

- `npm ci`
- `npm run build`
- Ручная проверка якорей: `#overview`, `#start`, `#materials` скроллят секции ниже фиксированной шапки.

## Примечания

Локально Vite предупреждает, что Node.js `20.18.0` ниже рекомендуемой версии `20.19+`, но сборка проходит успешно.
