### PR TITLE
fix(auth): make registration errors user friendly

### DIFF
--- a/src/styles/pages/Account.scss
+++ b/src/styles/pages/Account.scss
@@ -113,7 +113,12 @@
 
 .account-auth-error {
   margin: 0;
-  color: #ab1f1f;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #f2bcc1;
+  background: #fff1f2;
+  color: #9f1239;
+  font-weight: 700;
 }
 
 .account-auth-note {
@@ -123,6 +128,44 @@
 
 .account-auth-note a {
   color: #153b9d;
+}
+
+.account-password-help {
+  margin: -2px 0 2px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid #d8e1f4;
+  background: #f7f9fe;
+  color: #42506f;
+}
+
+.account-password-help p {
+  margin: 0 0 8px;
+  font-weight: 700;
+}
+
+.account-password-help ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.account-password-help li {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #ffffff;
+  border: 1px solid #dbe3f2;
+  color: #5b6683;
+  font-size: 0.92rem;
+}
+
+.account-password-help .account-password-rule-ok {
+  border-color: #a7d7bc;
+  background: #edf9f1;
+  color: #1f7a46;
 }
 
 .account-inline-link {

--- a/src/view/pages/account/AccountView.tsx
+++ b/src/view/pages/account/AccountView.tsx
@@ -55,6 +55,35 @@ function isStrongRegistrationPassword(password: string): boolean {
         && /[^A-Za-z\d]/.test(password);
 }
 
+function getPasswordRuleState(password: string) {
+    return [
+        {label: "12 или больше символов", passed: password.length >= 12},
+        {label: "строчная буква", passed: /[a-z]/.test(password)},
+        {label: "заглавная буква", passed: /[A-Z]/.test(password)},
+        {label: "цифра", passed: /\d/.test(password)},
+        {label: "специальный символ, например ! или -", passed: /[^A-Za-z\d]/.test(password)}
+    ];
+}
+
+function getFriendlyAuthError(error: unknown, mode: AuthMode): string {
+    const message = error instanceof Error ? error.message : "";
+    const lowerMessage = message.toLowerCase();
+
+    if (mode === "register" && (lowerMessage.includes("400") || lowerMessage.includes("bad request") || lowerMessage.includes("password policy"))) {
+        return "Пароль не подходит под требования безопасности. Проверьте подсказку под полем пароля и попробуйте ещё раз.";
+    }
+
+    if (mode === "register" && lowerMessage.includes("409")) {
+        return "Аккаунт с таким email уже существует. Переключитесь на вкладку «Вход» и войдите с этим email.";
+    }
+
+    if (lowerMessage.includes("502") || lowerMessage.includes("bad gateway")) {
+        return "Сервис авторизации временно недоступен. Попробуйте ещё раз через минуту.";
+    }
+
+    return message || (mode === "register" ? "Не удалось создать аккаунт." : "Не удалось выполнить вход.");
+}
+
 export function AccountView() {
     const location = useLocation();
     const navigate = useNavigate();
@@ -86,6 +115,8 @@ export function AccountView() {
     const hasServiceRole = (profile?.roles ?? []).some((role) => serviceRoles.has(role.toUpperCase()));
     const hasAdminRole = (profile?.roles ?? []).some((role) => role.toUpperCase() === "ADMIN");
     const profileSubject = profile?.subject ?? "";
+    const passwordRules = useMemo(() => getPasswordRuleState(authPassword.trim()), [authPassword]);
+    const failedPasswordRules = passwordRules.filter((rule) => !rule.passed);
 
     useEffect(() => {
         setAuthMode(getAuthModeFromSearch(location.search));
@@ -215,7 +246,7 @@ export function AccountView() {
                 }
 
                 if (!isStrongRegistrationPassword(authPassword.trim())) {
-                    setAuthError("Пароль должен быть не короче 12 символов и содержать строчную букву, заглавную букву, цифру и специальный символ.");
+                    setAuthError(`Добавьте в пароль: ${failedPasswordRules.map((rule) => rule.label).join(", ")}.`);
                     return;
                 }
 
@@ -232,7 +263,7 @@ export function AccountView() {
             setAuthPassword("");
             navigate("/account", {replace: true});
         } catch (authSubmitError) {
-            setAuthError(authSubmitError instanceof Error ? authSubmitError.message : "Не удалось выполнить вход.");
+            setAuthError(getFriendlyAuthError(authSubmitError, authMode));
         } finally {
             setIsAuthSubmitting(false);
         }
@@ -425,11 +456,26 @@ export function AccountView() {
                                 <input
                                     autoComplete={authMode === "register" ? "new-password" : "current-password"}
                                     onChange={(event) => setAuthPassword(event.target.value)}
-                                    placeholder={authMode === "register" ? "Минимум 12 символов, A-z, цифра и спецсимвол" : "Пароль"}
+                                    placeholder={authMode === "register" ? "Например: StrongPass-123!" : "Пароль"}
                                     type="password"
                                     value={authPassword}
                                 />
                             </label>
+                            {authMode === "register" && (
+                                <div className="account-password-help" aria-live="polite">
+                                    <p>Пароль должен содержать:</p>
+                                    <ul>
+                                        {passwordRules.map((rule) => (
+                                            <li
+                                                className={rule.passed ? "account-password-rule-ok" : ""}
+                                                key={rule.label}
+                                            >
+                                                {rule.passed ? "Готово: " : "Нужно: "}{rule.label}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
 
                             {authError.length > 0 && <p className="account-auth-error">{authError}</p>}
 


### PR DESCRIPTION
## Summary\n- replace technical registration failures with user-facing messages\n- add a live password requirements checklist on the registration form\n- style auth errors as clear inline guidance rather than raw HTTP text\n\n## Verification\n- npm ci\n- npm test\n- npm run build\n\n## Production note\nA hotfix with the same frontend assets has been copied into the running production frontend container for immediate verification.\n