### PR TITLE
fix(auth): hide technical auth notes in production

### DIFF
--- a/src/utils/localAuth.ts
+++ b/src/utils/localAuth.ts
@@ -179,7 +179,11 @@ async function resolveKeycloakLoginError(response: Response): Promise<Error> {
     const description = details?.error_description?.toLowerCase() ?? "";
 
     if (description.includes("account is not fully set up") || description.includes("update_password")) {
-        return new Error("Пароль в Keycloak помечен как временный. Зайдите в Keycloak напрямую и завершите смену пароля либо в админке задайте пароль с Temporary = Off.");
+        return new Error(
+            import.meta.env.PROD
+                ? "Вход временно недоступен для этой учетной записи. Обратитесь в поддержку."
+                : "Пароль в Keycloak помечен как временный. Зайдите в Keycloak напрямую и завершите смену пароля либо в админке задайте пароль с Temporary = Off."
+        );
     }
 
     if (description.includes("invalid user credentials")) {

--- a/src/view/pages/account/AccountView.tsx
+++ b/src/view/pages/account/AccountView.tsx
@@ -47,6 +47,14 @@ function getAuthModeFromSearch(search: string): AuthMode {
     return params.get("mode") === "register" ? "register" : "login";
 }
 
+function isStrongRegistrationPassword(password: string): boolean {
+    return password.length >= 12
+        && /[a-z]/.test(password)
+        && /[A-Z]/.test(password)
+        && /\d/.test(password)
+        && /[^A-Za-z\d]/.test(password);
+}
+
 export function AccountView() {
     const location = useLocation();
     const navigate = useNavigate();
@@ -189,8 +197,8 @@ export function AccountView() {
             return;
         }
 
-        if (authPassword.trim().length < 8) {
-            setAuthError("Пароль должен содержать минимум 8 символов.");
+        if (authPassword.trim().length === 0) {
+            setAuthError("Введите пароль.");
             setIsAuthSubmitting(false);
             return;
         }
@@ -203,6 +211,11 @@ export function AccountView() {
             } else {
                 if (normalizedName.length < 2) {
                     setAuthError("Введите имя не короче 2 символов.");
+                    return;
+                }
+
+                if (!isStrongRegistrationPassword(authPassword.trim())) {
+                    setAuthError("Пароль должен быть не короче 12 символов и содержать строчную букву, заглавную букву, цифру и специальный символ.");
                     return;
                 }
 
@@ -412,7 +425,7 @@ export function AccountView() {
                                 <input
                                     autoComplete={authMode === "register" ? "new-password" : "current-password"}
                                     onChange={(event) => setAuthPassword(event.target.value)}
-                                    placeholder="Минимум 8 символов"
+                                    placeholder={authMode === "register" ? "Минимум 12 символов, A-z, цифра и спецсимвол" : "Пароль"}
                                     type="password"
                                     value={authPassword}
                                 />

--- a/src/view/pages/account/AccountView.tsx
+++ b/src/view/pages/account/AccountView.tsx
@@ -440,10 +440,12 @@ export function AccountView() {
                             </button>
                         </form>
 
-                        <p className="account-auth-note">
-                            После входа через Keycloak вы сможете управлять историей донатов, сохранять избранные материалы и переходить в чаты.
-                            <Link to="/donate"> Поддержать проект</Link>
-                        </p>
+                        {!import.meta.env.PROD && (
+                            <p className="account-auth-note">
+                                После входа через Keycloak вы сможете управлять историей донатов, сохранять избранные материалы и переходить в чаты.
+                                <Link to="/donate"> Поддержать проект</Link>
+                            </p>
+                        )}
                     </div>
                 </section>
             )}


### PR DESCRIPTION
## Что сделано
- Скрыт блок `account-auth-note` в production.
- Подробное техническое сообщение Keycloak (temporary password) в production заменено на нейтральное.
- В dev-окружении подробная диагностика сохранена.

## Зачем
- Не показывать пользователям внутренние детали аутентификации на проде.
- Сохранить полезную диагностику для локальной разработки.

## Измененные файлы
- `src/view/pages/account/AccountView.tsx`
- `src/utils/localAuth.ts`
