### PR TITLE
feat(account): сценарий «Забыли пароль?» на странице входа

### DIFF
--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -3,6 +3,7 @@ import type {
     AccountChatSummaryResponse,
     AccountDonationResponse,
     AccountFavoriteResponse,
+    AccountPasswordResetResponse,
     AccountProfileResponse,
     CreateDonationRequest,
     RegisterAccountRequest,
@@ -17,6 +18,10 @@ export function getAccountProfile(): Promise<AccountProfileResponse> {
 
 export function registerAccount(request: RegisterAccountRequest): Promise<AccountProfileResponse> {
     return postJson<AccountProfileResponse, RegisterAccountRequest>("/api/account/register", request);
+}
+
+export function requestPasswordReset(email: string): Promise<AccountPasswordResetResponse> {
+    return postJson<AccountPasswordResetResponse, { email: string }>("/api/account/password/reset", {email});
 }
 
 export function updateAccountProfile(request: UpdateAccountProfileRequest): Promise<AccountProfileResponse> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -145,6 +145,11 @@ export interface RegisterAccountRequest {
     password: string
 }
 
+export interface AccountPasswordResetResponse {
+    status: string
+    message: string
+}
+
 export interface AccountChatSummaryResponse {
     chatId: string
     createdAt: string

--- a/src/styles/pages/Account.scss
+++ b/src/styles/pages/Account.scss
@@ -121,6 +121,32 @@
   font-weight: 700;
 }
 
+.account-auth-success {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid #b9e3c7;
+  background: #eefaf2;
+  color: #11663a;
+  font-weight: 700;
+}
+
+.account-auth-forgot-password {
+  justify-self: start;
+  border: 0;
+  background: transparent;
+  color: #153b9d;
+  font-weight: 700;
+  text-decoration: underline;
+  padding: 0;
+  cursor: pointer;
+}
+
+.account-auth-forgot-password:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .account-auth-note {
   margin: 12px 0 0;
   color: #5e6575;

--- a/src/view/pages/account/AccountView.tsx
+++ b/src/view/pages/account/AccountView.tsx
@@ -11,6 +11,7 @@ import {
     getAccountProfile,
     getDonations,
     getFavorites,
+    requestPasswordReset,
     registerAccount,
     updateAccountProfile
 } from "../../../api/accountApi";
@@ -92,6 +93,8 @@ export function AccountView() {
     const [authPassword, setAuthPassword] = useState("");
     const [authError, setAuthError] = useState("");
     const [isAuthSubmitting, setIsAuthSubmitting] = useState(false);
+    const [isPasswordResetSubmitting, setIsPasswordResetSubmitting] = useState(false);
+    const [passwordResetMessage, setPasswordResetMessage] = useState("");
     const [profile, setProfile] = useState<AccountProfileResponse | null>(() => {
         const existingSession = readLocalAuthSession();
         return existingSession ? buildProfileFromSession(existingSession) : null;
@@ -210,7 +213,29 @@ export function AccountView() {
     const switchAuthMode = (mode: AuthMode) => {
         setAuthMode(mode);
         setAuthError("");
+        setPasswordResetMessage("");
         navigate(`/account?mode=${mode}`, {replace: true});
+    };
+
+    const handlePasswordReset = async () => {
+        const normalizedEmail = authEmail.trim().toLowerCase();
+        if (normalizedEmail.length === 0) {
+            setAuthError("Введите email для восстановления пароля.");
+            setPasswordResetMessage("");
+            return;
+        }
+
+        setAuthError("");
+        setPasswordResetMessage("");
+        setIsPasswordResetSubmitting(true);
+        try {
+            const result = await requestPasswordReset(normalizedEmail);
+            setPasswordResetMessage(result.message);
+        } catch {
+            setPasswordResetMessage("Если аккаунт с таким email существует, инструкция по восстановлению пароля отправлена.");
+        } finally {
+            setIsPasswordResetSubmitting(false);
+        }
     };
 
     const handleAuthSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -477,6 +502,17 @@ export function AccountView() {
                             )}
 
                             {authError.length > 0 && <p className="account-auth-error">{authError}</p>}
+                            {passwordResetMessage.length > 0 && <p className="account-auth-success">{passwordResetMessage}</p>}
+                            {authMode === "login" && (
+                                <button
+                                    className="account-auth-forgot-password"
+                                    disabled={isPasswordResetSubmitting}
+                                    onClick={() => void handlePasswordReset()}
+                                    type="button"
+                                >
+                                    {isPasswordResetSubmitting ? "Отправляем инструкцию..." : "Забыли пароль?"}
+                                </button>
+                            )}
 
                             <button className="account-auth-submit" disabled={isAuthSubmitting} type="submit">
                                 {isAuthSubmitting


### PR DESCRIPTION
## Что сделано
- На форме входа добавлена кнопка `Забыли пароль?`.
- Добавлен вызов backend API восстановления пароля.
- Добавлено состояние отправки и сообщение об успешном/нейтральном результате.
- Добавлены стили для ссылки действия и блока успеха.

## UX-логика
- Пользователь вводит email и нажимает `Забыли пароль?`.
- Показывается нейтральный ответ: инструкция отправлена, если аккаунт существует.
- Ошибка backend не раскрывает наличие/отсутствие пользователя.

## Проверка
- `npm run build` (сборка успешна)

## Связанные задачи
- Closes #107
- Depends on backend issue #72
