### PR TITLE
content(chat): заменить «Чат с ИИ агентом» на «ИИ-чат»

### DIFF
--- a/src/view/pages/chat/ChatView.tsx
+++ b/src/view/pages/chat/ChatView.tsx
@@ -291,7 +291,7 @@ export function ChatView() {
             <Breadcrumbs items={[{label: "Главная", to: "/home"}, {label: "ИИ-чат"}]}/>
             <section className="chat-shell">
                 <header className="chat-header">
-                    <h1>Чат с ИИ агентом</h1>
+                    <h1>ИИ-чат</h1>
                     <p>Чат подключен к API. История диалога сохраняется между сессиями по `chatId`.</p>
                 </header>
 


### PR DESCRIPTION
## Что исправлено
- Заголовок страницы чата изменён с «Чат с ИИ агентом» на «ИИ-чат».

## Почему
- Единая терминология интерфейса: используем «ИИ-чат», без упоминания «ИИ-агент».

## Проверка
- Выполнен поиск по проекту: в пользовательских строках упоминаний «ИИ-агент» не осталось.
