### PR TITLE
ci(front): prune docker artifacts before deploy

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -94,6 +94,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
             "IMAGE='$IMAGE' GHCR_USER='$GHCR_USER' GHCR_TOKEN='$GHCR_TOKEN' bash -s" <<'REMOTE'
           set -euo pipefail
+          docker system prune -af
           mkdir -p ~/frontend
           cd ~/frontend
           cat > docker-compose.yml <<EOF2

--- a/src/view/pages/chat/ChatView.tsx
+++ b/src/view/pages/chat/ChatView.tsx
@@ -36,12 +36,28 @@ function formatMessageTime(value: string): string {
     return parsedDate.toLocaleTimeString([], {hour: "2-digit", minute: "2-digit"});
 }
 
+function normalizeWidget(widget: AiAssistantWidgetResponse | null | undefined): AiAssistantWidgetResponse | null {
+    if (!widget) {
+        return null;
+    }
+
+    return {
+        ...widget,
+        widgetType: widget.widgetType || "generic",
+        title: widget.title || "Подборка материалов",
+        subtitle: widget.subtitle ?? null,
+        items: Array.isArray(widget.items) ? widget.items : [],
+        actions: Array.isArray(widget.actions) ? widget.actions : [],
+        followUpOptions: Array.isArray(widget.followUpOptions) ? widget.followUpOptions : []
+    };
+}
+
 function mapHistoryMessage(message: ChatHistoryMessageResponse): ChatMessage {
     return {
         id: `history-${message.id}`,
         role: message.role,
         text: message.content,
-        widget: message.widget ?? null,
+        widget: normalizeWidget(message.widget),
         createdAt: formatMessageTime(message.createdAt)
     };
 }
@@ -254,7 +270,7 @@ export function ChatView() {
                 role: "assistant",
                 text: response.content,
                 createdAt: new Date().toLocaleTimeString([], {hour: "2-digit", minute: "2-digit"}),
-                widget: response.widget
+                widget: normalizeWidget(response.widget)
             };
 
             if (response.widget) {

--- a/src/view/pages/chat/ChatWidget.tsx
+++ b/src/view/pages/chat/ChatWidget.tsx
@@ -7,16 +7,22 @@ interface ChatWidgetProps {
 }
 
 export function ChatWidget({widget, onAction, onItemClick}: ChatWidgetProps) {
+    const widgetType = widget.widgetType || "generic";
+    const title = widget.title || "Подборка материалов";
+    const items = Array.isArray(widget.items) ? widget.items : [];
+    const actions = Array.isArray(widget.actions) ? widget.actions : [];
+    const followUpOptions = Array.isArray(widget.followUpOptions) ? widget.followUpOptions : [];
+
     return (
-        <div className={`chat-widget chat-widget-${widget.widgetType}`}>
+        <div className={`chat-widget chat-widget-${widgetType}`}>
             <div className="chat-widget-header">
-                <strong>{widget.title}</strong>
+                <strong>{title}</strong>
                 {widget.subtitle && <p>{widget.subtitle}</p>}
             </div>
 
-            {widget.items.length > 0 && (
+            {items.length > 0 && (
                 <div className="chat-widget-items">
-                    {widget.items.map((item) => (
+                    {items.map((item) => (
                         <button className="chat-widget-item" key={item.id} onClick={() => onItemClick(item)} type="button">
                             <span className="chat-widget-item-title">{item.title}</span>
                             {item.subtitle && <span className="chat-widget-item-subtitle">{item.subtitle}</span>}
@@ -26,9 +32,9 @@ export function ChatWidget({widget, onAction, onItemClick}: ChatWidgetProps) {
                 </div>
             )}
 
-            {widget.actions.length > 0 && (
+            {actions.length > 0 && (
                 <div className="chat-widget-actions">
-                    {widget.actions.map((action) => (
+                    {actions.map((action) => (
                         <button className="chat-widget-action" key={action.id} onClick={() => onAction(action)} type="button">
                             {action.label}
                         </button>
@@ -36,9 +42,9 @@ export function ChatWidget({widget, onAction, onItemClick}: ChatWidgetProps) {
                 </div>
             )}
 
-            {widget.followUpOptions.length > 0 && (
+            {followUpOptions.length > 0 && (
                 <div className="chat-widget-follow-up">
-                    {widget.followUpOptions.map((action) => (
+                    {followUpOptions.map((action) => (
                         <button className="chat-widget-follow-up-button" key={action.id} onClick={() => onAction(action)} type="button">
                             {action.label}
                         </button>


### PR DESCRIPTION
## Summary
- clean unused Docker artifacts on the production host before writing frontend compose and pulling the new image
- fixes frontend deploy failures caused by 'No space left on device'

## Validation
- previous frontend build/test passed in run 26993238889
- workflow-only change