### PR TITLE
content(docs): make Poprog intro user friendly

### DIFF
--- a/src/styles/common/PageShell.scss
+++ b/src/styles/common/PageShell.scss
@@ -74,8 +74,164 @@
   margin: 8px 0 0;
 }
 
+.site-intro-page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.site-intro-hero,
+.site-intro-section,
+.site-intro-grid article,
+.site-intro-links a {
+  border: 1px solid #dfe5f0;
+  background: #ffffff;
+}
+
+.site-intro-hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(30px, 5vw, 62px);
+  border-radius: 34px;
+  background:
+    radial-gradient(circle at 12% 20%, rgba(60, 119, 255, 0.28), transparent 32%),
+    linear-gradient(135deg, #07152f 0%, #123b92 58%, #0b78b7 100%);
+  color: #ffffff;
+}
+
+.site-intro-hero span {
+  display: inline-flex;
+  margin-bottom: 18px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  font-size: 0.92rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.site-intro-hero h1 {
+  max-width: 900px;
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 5rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.site-intro-hero p {
+  max-width: 920px;
+  margin: 24px 0 0;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: clamp(1.1rem, 2vw, 1.55rem);
+  line-height: 1.45;
+}
+
+.site-intro-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 30px;
+}
+
+.site-intro-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #0d1b3f;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.site-intro-actions a:nth-child(2) {
+  background: rgba(255, 255, 255, 0.14);
+  color: #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+}
+
+.site-intro-section {
+  padding: clamp(24px, 4vw, 42px);
+  border-radius: 28px;
+}
+
+.site-intro-section h2 {
+  margin: 0 0 12px;
+  font-size: clamp(1.8rem, 3vw, 3rem);
+  letter-spacing: -0.035em;
+}
+
+.site-intro-section p {
+  max-width: 1080px;
+  margin: 0;
+  color: #465066;
+  font-size: clamp(1.05rem, 1.7vw, 1.35rem);
+  line-height: 1.62;
+}
+
+.site-intro-grid,
+.site-intro-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.site-intro-grid article,
+.site-intro-links a {
+  min-height: 180px;
+  padding: 24px;
+  border-radius: 28px;
+}
+
+.site-intro-grid strong,
+.site-intro-links strong {
+  display: block;
+  color: #111827;
+  font-size: 1.2rem;
+}
+
+.site-intro-grid p,
+.site-intro-links span {
+  display: block;
+  margin-top: 12px;
+  color: #5a6377;
+  line-height: 1.55;
+}
+
+.site-intro-links {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.site-intro-links a {
+  color: inherit;
+  text-decoration: none;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.site-intro-links a:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(22, 34, 66, 0.12);
+}
+
 @media (max-width: 720px) {
   .site-page-content {
     padding: 0 16px;
+  }
+
+  .site-intro-hero,
+  .site-intro-section {
+    border-radius: 24px;
+  }
+
+  .site-intro-grid,
+  .site-intro-links {
+    grid-template-columns: 1fr;
+  }
+
+  .site-intro-grid article,
+  .site-intro-links a {
+    min-height: auto;
   }
 }

--- a/src/view/pages/docs/DocsView.tsx
+++ b/src/view/pages/docs/DocsView.tsx
@@ -1,5 +1,6 @@
 import BodyView from "../BodyView";
 import {Breadcrumbs} from "../../common/navigation/Breadcrumbs";
+import {Link} from "react-router-dom";
 import "../../../styles/common/PageShell.scss";
 
 export function DocsView() {
@@ -9,63 +10,74 @@ export function DocsView() {
 function page() {
     return (
         <main className="site-page">
-            <Breadcrumbs items={[{label: "Главная", to: "/home"}, {label: "Документация"}]}/>
-            <section className="site-page-content">
-                <h1>Документация</h1>
-                <p className="site-page-muted">
-                    Быстрые инструкции по запуску платформы, работе с API и практикам безопасной настройки окружения.
-                </p>
+            <Breadcrumbs items={[{label: "Главная", to: "/home"}, {label: "Что такое Poprog"}]}/>
+            <section className="site-page-content site-intro-page">
+                <section className="site-intro-hero">
+                    <span>Откройте для себя Poprog</span>
+                    <h1>Процесс-ориентированное программирование без лишней сложности</h1>
+                    <p>
+                        Poprog помогает смотреть на управляющую программу не как на запутанный набор условий,
+                        а как на понятную систему процессов: что должно происходить, в какой момент и как части
+                        системы взаимодействуют друг с другом.
+                    </p>
+                    <div className="site-intro-actions">
+                        <Link to="/projects">Посмотреть инструменты</Link>
+                        <Link to="/chat">Спросить ИИ-чат</Link>
+                    </div>
+                </section>
 
-                <h2>Быстрый старт</h2>
-                <ol>
-                    <li>Поднимите backend и frontend из рабочих директорий проекта.</li>
-                    <li>Проверьте доступность API `/api/publications/grouped` и `/api/student-works/grouped`.</li>
-                    <li>Откройте `/chat` и `/account` для проверки основных пользовательских сценариев.</li>
-                </ol>
+                <section className="site-intro-section">
+                    <h2>К чему это всё?</h2>
+                    <p>
+                        В промышленной автоматизации, embedded-системах и учебных проектах логика быстро становится
+                        сложной: есть датчики, события, состояния, аварийные сценарии и действия оператора. Poprog
+                        предлагает описывать такую логику через отдельные процессы. Каждый процесс отвечает за свою
+                        часть поведения, поэтому программу легче понимать, обсуждать, проверять и развивать.
+                    </p>
+                </section>
 
-                <h2>Документация по разделам</h2>
-                <ul>
-                    <li><strong>API и контракты:</strong> структура ответов, форматы ошибок, особенности поиска и фильтрации.</li>
-                    <li><strong>Контент:</strong> как публиковать материалы в разделах «Публикации», «Работы», «Проекты».</li>
-                    <li><strong>Личный кабинет:</strong> сценарии входа, профиль, история донатов и экспорт данных.</li>
-                    <li><strong>Интеграции:</strong> подключение внешних ссылок и безопасная обработка переходов.</li>
-                </ul>
+                <section className="site-intro-grid" aria-label="Польза процесс-ориентированного подхода">
+                    <article>
+                        <strong>Понятнее для команды</strong>
+                        <p>Инженеры, разработчики и исследователи видят одну модель поведения, а не набор разрозненных фрагментов кода.</p>
+                    </article>
+                    <article>
+                        <strong>Проще проверять</strong>
+                        <p>Когда логика разделена на процессы, легче найти ошибку, проверить сценарий и объяснить, почему система ведёт себя именно так.</p>
+                    </article>
+                    <article>
+                        <strong>Ближе к реальным задачам</strong>
+                        <p>Подход подходит для контроллеров, микроконтроллеров, промышленных установок и учебных стендов.</p>
+                    </article>
+                </section>
 
-                <h2>Интеграции и API</h2>
-                <ul>
-                    <li><strong>OpenAPI backend:</strong> используйте `/swagger-ui/index.html` для просмотра актуальных контрактов.</li>
-                    <li><strong>Поиск:</strong> проверьте ручки `/api/search`, `/api/publications/grouped`, `/api/student-works/grouped`.</li>
-                    <li><strong>Личный кабинет:</strong> блок `/api/account/*` покрывает профиль, чаты, избранное и историю донатов.</li>
-                    <li><strong>Пожертвования:</strong> публичный flow работает через `/api/donations`, а служебная аналитика через `/api/admin/donations/*`.</li>
-                </ul>
+                <section className="site-intro-section">
+                    <h2>Что находится внутри портала</h2>
+                    <p>
+                        Портал объединяет материалы и инструменты вокруг процесс-ориентированного подхода: языки Reflex,
+                        poST и IndustrialC, облачную среду RIDE, публикации, студенческие работы, примеры внедрения и
+                        Poprog Market с полезными утилитами.
+                    </p>
+                </section>
 
-                <h2>Требования к среде</h2>
-                <ul>
-                    <li><strong>Node.js:</strong> рекомендуется 20.19+ или 22.12+.</li>
-                    <li><strong>Java:</strong> 21 для backend-сервиса.</li>
-                    <li><strong>Инфраструктура:</strong> PostgreSQL и Elasticsearch для полной функциональности.</li>
-                </ul>
-
-                <h2>Безопасность и эксплуатация</h2>
-                <ul>
-                    <li>Debug-header auth режим допускается только в local/dev окружениях.</li>
-                    <li>Перед релизом проверьте отсутствие dev-флагов в production-конфигурации.</li>
-                    <li>Для публичных релизов включайте аудит логов по входам и операциям в аккаунте.</li>
-                </ul>
-
-                <h2>Частые вопросы</h2>
-                <ul>
-                    <li><strong>Почему кабинет не открывается?</strong> Убедитесь, что backend запущен и фронтенд отправляет debug headers или локальную сессию.</li>
-                    <li><strong>Почему файл не открывается по ссылке?</strong> Проверьте, что PDF находится в актуальном хранилище и backend отдает `inline` для просмотра.</li>
-                    <li><strong>Где искать админские функции?</strong> После входа под служебной ролью откройте «Мой аккаунт» и перейдите в админ-раздел донатов.</li>
-                </ul>
-
-                <h2>Устранение неполадок</h2>
-                <ul>
-                    <li><strong>`Failed to fetch`:</strong> обычно означает, что фронтенд смотрит не в тот `VITE_API_BASE_URL` или backend не запущен.</li>
-                    <li><strong>Пустые данные в кабинете:</strong> проверьте, что локальный вход выполнен и dev-headers разрешены в local-профиле backend.</li>
-                    <li><strong>Экспорт не скачивается:</strong> убедитесь, что браузер не блокирует загрузки и ответ backend не завершился ошибкой `401/403`.</li>
-                </ul>
+                <section className="site-intro-links" aria-label="Куда перейти дальше">
+                    <Link to="/projects/reflex">
+                        <strong>Reflex</strong>
+                        <span>Язык для микроконтроллеров и embedded-задач.</span>
+                    </Link>
+                    <Link to="/projects/post">
+                        <strong>poST</strong>
+                        <span>Процесс-ориентированное расширение Structured Text для ПЛК.</span>
+                    </Link>
+                    <Link to="/projects/ride-overview">
+                        <strong>RIDE</strong>
+                        <span>Среда, где можно работать с проектами и инструментами Poprog.</span>
+                    </Link>
+                    <Link to="/publications">
+                        <strong>Публикации</strong>
+                        <span>Научные и учебные материалы для более глубокого знакомства.</span>
+                    </Link>
+                </section>
             </section>
         </main>
     )


### PR DESCRIPTION
## Что сделано
- страница `/docs` переписана из технической инструкции в презентационное введение «Что такое Poprog»;
- убраны пользовательски неуместные блоки про backend, OpenAPI, debug headers и troubleshooting;
- добавлены объяснение процесс-ориентированного программирования, блок «К чему это всё?», карточки пользы и быстрые переходы к Reflex, poST, RIDE и публикациям;
- добавлены стили для hero-блока, карточек и адаптивной сетки.

## Проверки
- `npm run test:types`;
- `npm run build -- --base=/`;
- локальная проверка `/docs`: новый H1 отображается, технические слова `OpenAPI`, `debug`, `backend` на странице отсутствуют.

## Наблюдения
- Локальный Vite по-прежнему предупреждает, что Node.js `20.18.0` ниже рекомендуемого `20.19+`; сборка проходит.
